### PR TITLE
Start working on new floors

### DIFF
--- a/data/lib/layout.lua
+++ b/data/lib/layout.lua
@@ -562,6 +562,7 @@ function Layout.solarus_mixin(object, map)
     end
 
     function object:collect_on_finish()
+        zentropy.assert(self.style.room)
         current_map_x, current_map_y = object:pos_from_native(0, 0)
         mark_known_room(current_map_x, current_map_y)
         self:each_room(function (depth, leaf, info)
@@ -573,13 +574,14 @@ function Layout.solarus_mixin(object, map)
 
             local room_rng=self.rng:refine('room_' .. map_x .. '_' .. map_y)
             local room_name = self:room_name(depth, leaf)
+            local style = self.style:room(map_x, map_y):get_elect()
             local map_info = {
                 name=room_name,
                 doors={},
                 treasures={},
                 enemies=info.enemies,
                 rng=room_rng,
-                style=self.style,
+                style=style,
             }
             local doors = {}
             for native_dir, native_door in pairs(info.doors) do
@@ -601,7 +603,7 @@ function Layout.solarus_mixin(object, map)
 
             local x, y = 320 * map_x, 240 * map_y
 
-            map:include(x, y, 'rooms/room1', map_info, self.style)
+            map:include(x, y, 'rooms/room1', map_info, style)
         end)
     end
 

--- a/data/lib/map_include.lua
+++ b/data/lib/map_include.lua
@@ -171,6 +171,7 @@ local counter = 0
 function mapmeta:include(x, y, name, data, style)
     zentropy.assert(style)
     zentropy.assert(data.name)
+    print(name)
 
     local component_prefix = string.format('__include_%d_', counter)
     counter = counter + 1

--- a/data/lib/map_include.lua
+++ b/data/lib/map_include.lua
@@ -191,7 +191,7 @@ function mapmeta:include(x, y, name, data, style)
             method = function (self, properties)
                 if properties.pattern and string.sub(properties.pattern, 1, 12) == 'placeholder.' then
                     if properties.pattern == 'placeholder.floor.high' then
-                        properties.pattern = style:get_high_floor(data.name)
+                        properties.pattern = style.floor.high
                     end
                 end
                 return self:create_dynamic_tile(properties)

--- a/data/lib/mappings.lua
+++ b/data/lib/mappings.lua
@@ -1,3 +1,6 @@
+local StyleBuilder = require 'lib/stylebuilder.lua'
+local Prng = require 'lib/prng.lua'
+
 local dungeon_styles = {
     {
         -- palette = 'dungeon.tower_of_hera.1';
@@ -56,7 +59,7 @@ local dungeon_styles = {
             scope = 'dungeon',
             { 'entrance.1' },
         },
-        entrance_statue = {
+        entrance_pillar = {
             scope = 'dungeon',
             { 'entrance_pillar.4' },
         },
@@ -201,6 +204,13 @@ function styles.choose(current_tier, rng)
         end
     end
 
+    local style_rng = Prng:new{ path=zentropy.game.get_seed() }:refine('style')
+    local style_builder = StyleBuilder.new(style_rng)
+    for _, v in ipairs(dungeon_styles) do
+        style_builder:add_mapping(v)
+    end
+    style_builder = style_builder:dungeon(current_tier)
+
     local style = choose_style(current_tier, rng:refine('style'))
     local enemies = get_enemies(current_tier)
     local complexity = get_complexity(current_tier)
@@ -209,19 +219,7 @@ function styles.choose(current_tier, rng)
         destructibles=style.destructibles,
         enemies=enemies,
         complexity=complexity,
-        get_high_floor = scoped(style.floor, rng:refine('floor'), function (candidate) return candidate.high end ),
-        get_low_floor = scoped(style.floor, rng:refine('floor'), function (candidate) return candidate.low end ),
-        get_wall_pillars = scoped(style.wall_pillars, rng:refine('wall_pillars')),
-        get_drapes = scoped(style.drapes, rng:refine('drapes')),
-        get_statues = scoped(style.statues, rng:refine('statues')),
-        get_wall_statues = scoped(style.wall_statues, rng:refine('wall_statues')),
-        get_barrier = scoped(style.barrier, rng:refine('barrier')),
-        get_hole = scoped(style.hole, rng:refine('hole')),
-        get_big_barrier = scoped(style.big_barrier, rng:refine('big_barrier')),
-        get_stage = scoped(style.stage, rng:refine('stage')),
-        get_entrance = scoped(style.entrance, rng:refine('entrance')),
-        get_entrance_statue = scoped(style.entrance_statue, rng:refine('entrance_statue')),
-        get_music = scoped(style.music, rng:refine('music')),
+        style_builder=style_builder,
     }
     return styles
 end

--- a/data/lib/stylebuilder.lua
+++ b/data/lib/stylebuilder.lua
@@ -1,0 +1,120 @@
+local StyleBuilder = {}
+
+local StyleBuilderProto = {}
+
+local StyleBuilderMeta = {}
+
+function StyleBuilderMeta.__index(table, key)
+    return StyleBuilderProto[key]
+end
+
+function StyleBuilder.new(rng)
+    o = {
+        mappings = {},
+        rng = rng,
+    }
+    o.quest_style = o,
+    setmetatable(o, StyleBuilderMeta)
+    return o
+end
+
+local group_names = {
+    'barrier',
+    'big_barrier',
+    'drapes',
+    'entrance',
+    'entrance_pillar',
+    'floor',
+    'hole',
+    'music',
+    'stage',
+    'statues',
+    'wall_pillars',
+    'wall_statues',
+}
+
+function StyleBuilderProto:_resolve_groups(scope)
+    zentropy.assert(self.dungeon_style)
+    local scope_style = self[scope .. '_style']
+    local rng = scope_style.rng:refine('elect')
+    scope_style.elect = {}
+    for _, group_name in ipairs(group_names) do
+        local group = self.dungeon_style.mapping[group_name]
+        if group.scope == scope then
+            local group_rng = rng:refine(group_name)
+            local seq = group_rng:seq()
+            local candidate
+            for _, v in ipairs(group) do
+                if seq(v.p or 1) then
+                    candidate = v
+                end
+            end
+            if table.getn(candidate) > 0 then
+                local _, elect = group_rng:ichoose(candidate)
+                scope_style.elect[group_name] = elect
+            else
+                scope_style.elect[group_name] = {}
+                for k, v in pairs(candidate) do
+                    if k ~= 'p' then
+                        local _, elect = group_rng:refine(k):choose(v)
+                        scope_style.elect[group_name][k] = elect
+                    end
+                end
+            end
+        end
+    end
+end
+
+function StyleBuilderProto:dungeon(tier)
+    local seq = self.quest_style.rng:seq()
+    o = {
+        quest_style = self.quest_style,
+        tier = tier,
+        rng = self.quest_style.rng:refine('tier_' .. tier),
+        elect = {},
+    }
+    for _, mapping in ipairs(self.quest_style.mappings) do
+        if tier >= mapping.tier_introduction then
+            if seq(mapping.p or 1.0) then
+                o.mapping = mapping
+            end
+        end
+    end
+    zentropy.assert(o.mapping)
+    o.dungeon_style = o
+    setmetatable(o, StyleBuilderMeta)
+    o:_resolve_groups('dungeon')
+    return o
+end
+
+function StyleBuilderProto:room(x, y)
+    o = {
+        quest_style = self.quest_style,
+        dungeon_style = self.dungeon_style,
+        x = x,
+        y = y,
+        rng = self.dungeon_style.rng:refine('room_' .. x .. '_' .. y),
+        elect = {},
+    }
+    o.room_style = o
+    setmetatable(o, StyleBuilderMeta)
+    o:_resolve_groups('room')
+    return o
+end
+
+function StyleBuilderProto:add_mapping(mapping)
+    table.insert(self.quest_style.mappings, mapping)
+    return o
+end
+
+function StyleBuilderProto:get_elect()
+    local o = {}
+    local mt = {}
+    function mt.__index(t, k)
+        return (self.room_style and self.room_style.elect[k]) or self.dungeon_style.elect[k]
+    end
+    setmetatable(o, mt)
+    return o
+end
+
+return StyleBuilder

--- a/data/maps/components/door/door_bigkey_n_200777_1.dat
+++ b/data/maps/components/door/door_bigkey_n_200777_1.dat
@@ -10,12 +10,147 @@ properties{
 }
 
 tile{
-  layer = 1,
+  layer = 0,
   x = 56,
   y = 56,
   width = 208,
-  height = 48,
+  height = 128,
   pattern = "hole",
+}
+
+tile{
+  layer = 1,
+  x = 24,
+  y = 24,
+  width = 272,
+  height = 32,
+  pattern = "placeholder.floor.high",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 32,
+  width = 256,
+  height = 8,
+  pattern = "wall_border.high.n",
+}
+
+tile{
+  layer = 1,
+  x = 24,
+  y = 56,
+  width = 32,
+  height = 128,
+  pattern = "placeholder.floor.high",
+}
+
+tile{
+  layer = 1,
+  x = 264,
+  y = 56,
+  width = 32,
+  height = 128,
+  pattern = "placeholder.floor.high",
+}
+
+tile{
+  layer = 1,
+  x = 24,
+  y = 184,
+  width = 272,
+  height = 32,
+  pattern = "placeholder.floor.high",
+}
+
+tile{
+  layer = 1,
+  x = 56,
+  y = 104,
+  width = 16,
+  height = 32,
+  pattern = "placeholder.floor.high",
+}
+
+tile{
+  layer = 1,
+  x = 248,
+  y = 104,
+  width = 16,
+  height = 32,
+  pattern = "placeholder.floor.high",
+}
+
+tile{
+  layer = 1,
+  x = 136,
+  y = 168,
+  width = 48,
+  height = 16,
+  pattern = "placeholder.floor.high",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 208,
+  width = 96,
+  height = 24,
+  pattern = "high_wall.s",
+}
+
+tile{
+  layer = 1,
+  x = 192,
+  y = 208,
+  width = 96,
+  height = 24,
+  pattern = "high_wall.s",
+}
+
+tile{
+  layer = 1,
+  x = 288,
+  y = 144,
+  width = 24,
+  height = 64,
+  pattern = "high_wall.e",
+}
+
+tile{
+  layer = 1,
+  x = 288,
+  y = 32,
+  width = 24,
+  height = 64,
+  pattern = "high_wall.e",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 8,
+  width = 256,
+  height = 24,
+  pattern = "high_wall.n",
+}
+
+tile{
+  layer = 1,
+  x = 8,
+  y = 144,
+  width = 24,
+  height = 64,
+  pattern = "high_wall.w",
+}
+
+tile{
+  layer = 1,
+  x = 8,
+  y = 32,
+  width = 24,
+  height = 64,
+  pattern = "high_wall.w",
 }
 
 tile{
@@ -25,33 +160,6 @@ tile{
   width = 80,
   height = 40,
   pattern = "carpet_border",
-}
-
-tile{
-  layer = 1,
-  x = 184,
-  y = 136,
-  width = 80,
-  height = 48,
-  pattern = "hole",
-}
-
-tile{
-  layer = 1,
-  x = 56,
-  y = 136,
-  width = 80,
-  height = 48,
-  pattern = "hole",
-}
-
-tile{
-  layer = 1,
-  x = 72,
-  y = 80,
-  width = 176,
-  height = 88,
-  pattern = "hole",
 }
 
 tile{
@@ -504,14 +612,113 @@ tile{
   pattern = "chasm_wall.e",
 }
 
+tile{
+  layer = 1,
+  x = 8,
+  y = 8,
+  width = 24,
+  height = 24,
+  pattern = "high_wall_inner_corner.nw",
+}
+
+tile{
+  layer = 1,
+  x = 288,
+  y = 8,
+  width = 24,
+  height = 24,
+  pattern = "high_wall_inner_corner.ne",
+}
+
+tile{
+  layer = 1,
+  x = 8,
+  y = 208,
+  width = 24,
+  height = 24,
+  pattern = "high_wall_inner_corner.sw",
+}
+
+tile{
+  layer = 1,
+  x = 288,
+  y = 208,
+  width = 24,
+  height = 24,
+  pattern = "high_wall_inner_corner.se",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 200,
+  width = 256,
+  height = 8,
+  pattern = "wall_border.high.s",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 32,
+  width = 8,
+  height = 176,
+  pattern = "wall_border.high.w",
+}
+
+tile{
+  layer = 1,
+  x = 280,
+  y = 32,
+  width = 8,
+  height = 176,
+  pattern = "wall_border.high.e",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 32,
+  width = 8,
+  height = 8,
+  pattern = "wall_border_inner_corner.high.nw",
+}
+
+tile{
+  layer = 1,
+  x = 280,
+  y = 32,
+  width = 8,
+  height = 8,
+  pattern = "wall_border_inner_corner.high.ne",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 200,
+  width = 8,
+  height = 8,
+  pattern = "wall_border_inner_corner.high.sw",
+}
+
+tile{
+  layer = 1,
+  x = 280,
+  y = 200,
+  width = 8,
+  height = 8,
+  pattern = "wall_border_inner_corner.high.se",
+}
+
 dynamic_tile{
+  name = "door_open",
   layer = 1,
   x = 152,
   y = 16,
+  pattern = "door_floor.n",
   width = 16,
   height = 16,
-  name = "door_open",
-  pattern = "door_floor.n",
   enabled_at_start = true,
 }
 
@@ -525,12 +732,12 @@ wall{
 }
 
 sensor{
+  name = "sensor",
   layer = 1,
   x = 160,
   y = 45,
   width = 16,
   height = 16,
-  name = "sensor",
 }
 
 stream{
@@ -580,4 +787,39 @@ tile{
   pattern = "boss_entrance_pillar.r.top",
 }
 
+tile{
+  layer = 2,
+  x = 0,
+  y = 0,
+  width = 320,
+  height = 8,
+  pattern = "ceiling",
+}
+
+tile{
+  layer = 2,
+  x = 0,
+  y = 232,
+  width = 320,
+  height = 8,
+  pattern = "ceiling",
+}
+
+tile{
+  layer = 2,
+  x = 312,
+  y = 8,
+  width = 8,
+  height = 224,
+  pattern = "ceiling",
+}
+
+tile{
+  layer = 2,
+  x = 0,
+  y = 8,
+  width = 8,
+  height = 224,
+  pattern = "ceiling",
+}
 

--- a/data/maps/components/door/door_bigkey_n_200777_5.dat
+++ b/data/maps/components/door/door_bigkey_n_200777_5.dat
@@ -11,6 +11,60 @@ properties{
 
 tile{
   layer = 1,
+  x = 24,
+  y = 24,
+  width = 272,
+  height = 192,
+  pattern = "placeholder.floor.high",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 200,
+  width = 256,
+  height = 8,
+  pattern = "wall_border.high.s",
+}
+
+tile{
+  layer = 1,
+  x = 280,
+  y = 32,
+  width = 8,
+  height = 176,
+  pattern = "wall_border.high.e",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 32,
+  width = 8,
+  height = 176,
+  pattern = "wall_border.high.w",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 32,
+  width = 256,
+  height = 8,
+  pattern = "wall_border.high.n",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 8,
+  width = 256,
+  height = 24,
+  pattern = "high_wall.n",
+}
+
+tile{
+  layer = 1,
   x = 120,
   y = 40,
   width = 80,
@@ -189,6 +243,132 @@ tile{
   pattern = "placeholder.drapes.n",
 }
 
+tile{
+  layer = 1,
+  x = 8,
+  y = 8,
+  width = 24,
+  height = 24,
+  pattern = "high_wall_inner_corner.nw",
+}
+
+tile{
+  layer = 1,
+  x = 288,
+  y = 8,
+  width = 24,
+  height = 24,
+  pattern = "high_wall_inner_corner.ne",
+}
+
+tile{
+  layer = 1,
+  x = 8,
+  y = 208,
+  width = 24,
+  height = 24,
+  pattern = "high_wall_inner_corner.sw",
+}
+
+tile{
+  layer = 1,
+  x = 288,
+  y = 208,
+  width = 24,
+  height = 24,
+  pattern = "high_wall_inner_corner.se",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 208,
+  width = 96,
+  height = 24,
+  pattern = "high_wall.s",
+}
+
+tile{
+  layer = 1,
+  x = 192,
+  y = 208,
+  width = 96,
+  height = 24,
+  pattern = "high_wall.s",
+}
+
+tile{
+  layer = 1,
+  x = 8,
+  y = 32,
+  width = 24,
+  height = 64,
+  pattern = "high_wall.w",
+}
+
+tile{
+  layer = 1,
+  x = 8,
+  y = 144,
+  width = 24,
+  height = 64,
+  pattern = "high_wall.w",
+}
+
+tile{
+  layer = 1,
+  x = 288,
+  y = 32,
+  width = 24,
+  height = 64,
+  pattern = "high_wall.e",
+}
+
+tile{
+  layer = 1,
+  x = 288,
+  y = 144,
+  width = 24,
+  height = 64,
+  pattern = "high_wall.e",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 32,
+  width = 8,
+  height = 8,
+  pattern = "wall_border_inner_corner.high.nw",
+}
+
+tile{
+  layer = 1,
+  x = 280,
+  y = 32,
+  width = 8,
+  height = 8,
+  pattern = "wall_border_inner_corner.high.ne",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 200,
+  width = 8,
+  height = 8,
+  pattern = "wall_border_inner_corner.high.sw",
+}
+
+tile{
+  layer = 1,
+  x = 280,
+  y = 200,
+  width = 8,
+  height = 8,
+  pattern = "wall_border_inner_corner.high.se",
+}
+
 dynamic_tile{
   name = "door_open",
   layer = 1,
@@ -345,4 +525,39 @@ tile{
   pattern = "pillar.top",
 }
 
+tile{
+  layer = 2,
+  x = 0,
+  y = 0,
+  width = 320,
+  height = 8,
+  pattern = "ceiling",
+}
+
+tile{
+  layer = 2,
+  x = 0,
+  y = 232,
+  width = 320,
+  height = 8,
+  pattern = "ceiling",
+}
+
+tile{
+  layer = 2,
+  x = 0,
+  y = 8,
+  width = 8,
+  height = 224,
+  pattern = "ceiling",
+}
+
+tile{
+  layer = 2,
+  x = 312,
+  y = 8,
+  width = 8,
+  height = 224,
+  pattern = "ceiling",
+}
 

--- a/data/maps/components/door/door_bigkey_n_202777_water.dat
+++ b/data/maps/components/door/door_bigkey_n_202777_water.dat
@@ -11,6 +11,60 @@ properties{
 
 tile{
   layer = 1,
+  x = 24,
+  y = 24,
+  width = 272,
+  height = 192,
+  pattern = "placeholder.floor.high",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 96,
+  width = 8,
+  height = 48,
+  pattern = "wall_border.high.w",
+}
+
+tile{
+  layer = 1,
+  x = 280,
+  y = 96,
+  width = 8,
+  height = 48,
+  pattern = "wall_border.high.e",
+}
+
+tile{
+  layer = 1,
+  x = 136,
+  y = 32,
+  width = 48,
+  height = 8,
+  pattern = "wall_border.high.n",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 8,
+  width = 256,
+  height = 24,
+  pattern = "high_wall.n",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 208,
+  width = 256,
+  height = 24,
+  pattern = "high_wall.s",
+}
+
+tile{
+  layer = 1,
   x = 40,
   y = 56,
   width = 64,
@@ -385,15 +439,6 @@ tile{
   width = 24,
   height = 40,
   pattern = "low_wall.w",
-}
-
-tile{
-  layer = 1,
-  x = 144,
-  y = 144,
-  width = 32,
-  height = 32,
-  pattern = "placeholder.statue",
 }
 
 tile{
@@ -1080,6 +1125,96 @@ tile{
   pattern = "shallow_water_border.e",
 }
 
+tile{
+  layer = 1,
+  x = 8,
+  y = 8,
+  width = 24,
+  height = 24,
+  pattern = "high_wall_inner_corner.nw",
+}
+
+tile{
+  layer = 1,
+  x = 288,
+  y = 8,
+  width = 24,
+  height = 24,
+  pattern = "high_wall_inner_corner.ne",
+}
+
+tile{
+  layer = 1,
+  x = 288,
+  y = 208,
+  width = 24,
+  height = 24,
+  pattern = "high_wall_inner_corner.se",
+}
+
+tile{
+  layer = 1,
+  x = 8,
+  y = 208,
+  width = 24,
+  height = 24,
+  pattern = "high_wall_inner_corner.sw",
+}
+
+tile{
+  layer = 1,
+  x = 8,
+  y = 144,
+  width = 24,
+  height = 64,
+  pattern = "high_wall.w",
+}
+
+tile{
+  layer = 1,
+  x = 8,
+  y = 32,
+  width = 24,
+  height = 64,
+  pattern = "high_wall.w",
+}
+
+tile{
+  layer = 1,
+  x = 288,
+  y = 32,
+  width = 24,
+  height = 64,
+  pattern = "high_wall.e",
+}
+
+tile{
+  layer = 1,
+  x = 288,
+  y = 144,
+  width = 24,
+  height = 64,
+  pattern = "high_wall.e",
+}
+
+tile{
+  layer = 1,
+  x = 128,
+  y = 200,
+  width = 64,
+  height = 8,
+  pattern = "wall_border.high.s",
+}
+
+tile{
+  layer = 1,
+  x = 144,
+  y = 144,
+  width = 32,
+  height = 32,
+  pattern = "statue.7",
+}
+
 dynamic_tile{
   name = "door_open",
   layer = 1,
@@ -1208,5 +1343,41 @@ tile{
   width = 16,
   height = 16,
   pattern = "pedestal_torch_top",
+}
+
+tile{
+  layer = 2,
+  x = 0,
+  y = 8,
+  width = 8,
+  height = 224,
+  pattern = "ceiling",
+}
+
+tile{
+  layer = 2,
+  x = 312,
+  y = 8,
+  width = 8,
+  height = 224,
+  pattern = "ceiling",
+}
+
+tile{
+  layer = 2,
+  x = 0,
+  y = 232,
+  width = 320,
+  height = 8,
+  pattern = "ceiling",
+}
+
+tile{
+  layer = 2,
+  x = 0,
+  y = 0,
+  width = 320,
+  height = 8,
+  pattern = "ceiling",
 }
 

--- a/data/maps/components/door/door_bigkey_s_002000_1.dat
+++ b/data/maps/components/door/door_bigkey_s_002000_1.dat
@@ -11,6 +11,15 @@ properties{
 
 tile{
   layer = 1,
+  x = 144,
+  y = 208,
+  width = 32,
+  height = 24,
+  pattern = "high_wall.s",
+}
+
+tile{
+  layer = 1,
   x = 168,
   y = 208,
   width = 8,
@@ -55,13 +64,13 @@ tile{
 }
 
 dynamic_tile{
+  name = "door_open",
   layer = 1,
   x = 152,
   y = 208,
+  pattern = "door_floor.s",
   width = 16,
   height = 16,
-  name = "door_open",
-  pattern = "door_floor.s",
   enabled_at_start = true,
 }
 
@@ -75,12 +84,12 @@ wall{
 }
 
 sensor{
+  name = "sensor",
   layer = 1,
   x = 160,
   y = 205,
   width = 16,
   height = 16,
-  name = "sensor",
 }
 
 stream{
@@ -122,5 +131,4 @@ tile{
   height = 8,
   pattern = "closed_door_top.s",
 }
-
 

--- a/data/maps/components/door/door_closed_n_200000_1.dat
+++ b/data/maps/components/door/door_closed_n_200000_1.dat
@@ -11,6 +11,15 @@ properties{
 
 tile{
   layer = 1,
+  x = 144,
+  y = 8,
+  width = 32,
+  height = 24,
+  pattern = "high_wall.n",
+}
+
+tile{
+  layer = 1,
   x = 168,
   y = 16,
   width = 8,
@@ -55,13 +64,13 @@ tile{
 }
 
 dynamic_tile{
+  name = "door_open",
   layer = 1,
   x = 152,
   y = 16,
+  pattern = "door_floor.n",
   width = 16,
   height = 16,
-  name = "door_open",
-  pattern = "door_floor.n",
   enabled_at_start = true,
 }
 
@@ -75,21 +84,21 @@ wall{
 }
 
 sensor{
+  name = "sensor",
   layer = 1,
   x = 160,
   y = 45,
   width = 16,
   height = 16,
-  name = "sensor",
 }
 
 sensor{
+  name = "entering",
   layer = 1,
   x = 160,
   y = -3,
   width = 16,
   height = 16,
-  name = "entering",
 }
 
 tile{
@@ -109,5 +118,4 @@ tile{
   height = 8,
   pattern = "closed_door_top.n",
 }
-
 

--- a/data/maps/components/door/door_closed_s_002000_1.dat
+++ b/data/maps/components/door/door_closed_s_002000_1.dat
@@ -11,6 +11,15 @@ properties{
 
 tile{
   layer = 1,
+  x = 144,
+  y = 208,
+  width = 32,
+  height = 24,
+  pattern = "high_wall.s",
+}
+
+tile{
+  layer = 1,
   x = 168,
   y = 208,
   width = 8,
@@ -55,13 +64,13 @@ tile{
 }
 
 dynamic_tile{
+  name = "door_open",
   layer = 1,
   x = 152,
   y = 208,
+  pattern = "door_floor.s",
   width = 16,
   height = 16,
-  name = "door_open",
-  pattern = "door_floor.s",
   enabled_at_start = true,
 }
 
@@ -75,21 +84,21 @@ wall{
 }
 
 sensor{
+  name = "sensor",
   layer = 1,
   x = 160,
   y = 205,
   width = 16,
   height = 16,
-  name = "sensor",
 }
 
 sensor{
+  name = "entering",
   layer = 1,
   x = 160,
   y = 253,
   width = 16,
   height = 16,
-  name = "entering",
 }
 
 tile{
@@ -109,5 +118,4 @@ tile{
   height = 8,
   pattern = "closed_door_top.s",
 }
-
 

--- a/data/maps/components/door/door_entrance.lua
+++ b/data/maps/components/door/door_entrance.lua
@@ -48,13 +48,13 @@ function door_entrance.init(map, data, direction)
     })
 
     local style = map:get_style()
-    local entrance_statue_prefix = style:get_entrance_statue(data.name)
+    local entrance_pillar_prefix = style.entrance_pillar
 
     map:create_dynamic_tile({
         layer=layer,
         x=x,
         y=y+16,
-        pattern=entrance_statue_prefix .. '.r.bottom',
+        pattern=entrance_pillar_prefix .. '.r.bottom',
         width=24,
         height=24,
         enabled_at_start=true,
@@ -64,7 +64,7 @@ function door_entrance.init(map, data, direction)
         layer=layer+1,
         x=x,
         y=y+40,
-        pattern=entrance_statue_prefix .. '.r.top',
+        pattern=entrance_pillar_prefix .. '.r.top',
         width=24,
         height=8,
         enabled_at_start=true,
@@ -74,7 +74,7 @@ function door_entrance.init(map, data, direction)
         layer=layer,
         x=x+56,
         y=y+16,
-        pattern=entrance_statue_prefix .. '.l.bottom',
+        pattern=entrance_pillar_prefix .. '.l.bottom',
         width=24,
         height=24,
         enabled_at_start=true,
@@ -84,7 +84,7 @@ function door_entrance.init(map, data, direction)
         layer=layer+1,
         x=x+56,
         y=y+40,
-        pattern=entrance_statue_prefix .. '.l.top',
+        pattern=entrance_pillar_prefix .. '.l.top',
         width=24,
         height=8,
         enabled_at_start=true,

--- a/data/maps/components/door/door_entrance_s_002777_3.dat
+++ b/data/maps/components/door/door_entrance_s_002777_3.dat
@@ -11,6 +11,114 @@ properties{
 
 tile{
   layer = 1,
+  x = 24,
+  y = 24,
+  width = 272,
+  height = 192,
+  pattern = "placeholder.floor.high",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 8,
+  width = 96,
+  height = 24,
+  pattern = "high_wall.n",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 208,
+  width = 256,
+  height = 24,
+  pattern = "high_wall.s",
+}
+
+tile{
+  layer = 1,
+  x = 8,
+  y = 32,
+  width = 24,
+  height = 64,
+  pattern = "high_wall.w",
+}
+
+tile{
+  layer = 1,
+  x = 288,
+  y = 32,
+  width = 24,
+  height = 64,
+  pattern = "high_wall.e",
+}
+
+tile{
+  layer = 1,
+  x = 8,
+  y = 8,
+  width = 24,
+  height = 24,
+  pattern = "high_wall_inner_corner.nw",
+}
+
+tile{
+  layer = 1,
+  x = 288,
+  y = 8,
+  width = 24,
+  height = 24,
+  pattern = "high_wall_inner_corner.ne",
+}
+
+tile{
+  layer = 1,
+  x = 288,
+  y = 208,
+  width = 24,
+  height = 24,
+  pattern = "high_wall_inner_corner.se",
+}
+
+tile{
+  layer = 1,
+  x = 8,
+  y = 208,
+  width = 24,
+  height = 24,
+  pattern = "high_wall_inner_corner.sw",
+}
+
+tile{
+  layer = 1,
+  x = 8,
+  y = 144,
+  width = 24,
+  height = 64,
+  pattern = "high_wall.w",
+}
+
+tile{
+  layer = 1,
+  x = 288,
+  y = 144,
+  width = 24,
+  height = 64,
+  pattern = "high_wall.e",
+}
+
+tile{
+  layer = 1,
+  x = 192,
+  y = 8,
+  width = 96,
+  height = 24,
+  pattern = "high_wall.n",
+}
+
+tile{
+  layer = 1,
   x = 216,
   y = 96,
   width = 24,
@@ -225,6 +333,96 @@ tile{
   pattern = "placeholder.barrier.2",
 }
 
+tile{
+  layer = 1,
+  x = 32,
+  y = 32,
+  width = 256,
+  height = 8,
+  pattern = "wall_border.high.n",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 200,
+  width = 256,
+  height = 8,
+  pattern = "wall_border.high.s",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 32,
+  width = 8,
+  height = 176,
+  pattern = "wall_border.high.w",
+}
+
+tile{
+  layer = 1,
+  x = 280,
+  y = 32,
+  width = 8,
+  height = 176,
+  pattern = "wall_border.high.e",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 32,
+  width = 8,
+  height = 8,
+  pattern = "wall_border_inner_corner.high.nw",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 200,
+  width = 8,
+  height = 8,
+  pattern = "wall_border_inner_corner.high.sw",
+}
+
+tile{
+  layer = 1,
+  x = 280,
+  y = 200,
+  width = 8,
+  height = 8,
+  pattern = "wall_border_inner_corner.high.se",
+}
+
+tile{
+  layer = 1,
+  x = 280,
+  y = 32,
+  width = 8,
+  height = 8,
+  pattern = "wall_border_inner_corner.high.ne",
+}
+
+tile{
+  layer = 1,
+  x = 128,
+  y = 176,
+  width = 32,
+  height = 24,
+  pattern = "entrance_floor.1.3",
+}
+
+tile{
+  layer = 1,
+  x = 160,
+  y = 176,
+  width = 32,
+  height = 24,
+  pattern = "entrance_floor.1.4",
+}
+
 dynamic_tile{
   name = "tile_8",
   layer = 1,
@@ -336,4 +534,39 @@ tile{
   pattern = "closed_door_top.s",
 }
 
+tile{
+  layer = 2,
+  x = 0,
+  y = 8,
+  width = 8,
+  height = 224,
+  pattern = "ceiling",
+}
+
+tile{
+  layer = 2,
+  x = 312,
+  y = 8,
+  width = 8,
+  height = 224,
+  pattern = "ceiling",
+}
+
+tile{
+  layer = 2,
+  x = 0,
+  y = 0,
+  width = 320,
+  height = 8,
+  pattern = "ceiling",
+}
+
+tile{
+  layer = 2,
+  x = 0,
+  y = 232,
+  width = 320,
+  height = 8,
+  pattern = "ceiling",
+}
 

--- a/data/maps/components/door/door_entrance_s_002777_4.dat
+++ b/data/maps/components/door/door_entrance_s_002777_4.dat
@@ -11,6 +11,33 @@ properties{
 
 tile{
   layer = 1,
+  x = 24,
+  y = 24,
+  width = 272,
+  height = 192,
+  pattern = "placeholder.floor.high",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 8,
+  width = 96,
+  height = 24,
+  pattern = "high_wall.n",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 208,
+  width = 256,
+  height = 24,
+  pattern = "high_wall.s",
+}
+
+tile{
+  layer = 1,
   x = 224,
   y = 40,
   width = 8,
@@ -121,16 +148,7 @@ tile{
   layer = 1,
   x = 32,
   y = 32,
-  width = 64,
-  height = 8,
-  pattern = "wall_border.high.n",
-}
-
-tile{
-  layer = 1,
-  x = 224,
-  y = 32,
-  width = 64,
+  width = 256,
   height = 8,
   pattern = "wall_border.high.n",
 }
@@ -139,16 +157,7 @@ tile{
   layer = 1,
   x = 32,
   y = 200,
-  width = 64,
-  height = 8,
-  pattern = "wall_border.high.s",
-}
-
-tile{
-  layer = 1,
-  x = 224,
-  y = 200,
-  width = 64,
+  width = 256,
   height = 8,
   pattern = "wall_border.high.s",
 }
@@ -205,6 +214,105 @@ tile{
   width = 8,
   height = 8,
   pattern = "wall_border_inner_corner.high.ne",
+}
+
+tile{
+  layer = 1,
+  x = 8,
+  y = 8,
+  width = 24,
+  height = 24,
+  pattern = "high_wall_inner_corner.nw",
+}
+
+tile{
+  layer = 1,
+  x = 8,
+  y = 208,
+  width = 24,
+  height = 24,
+  pattern = "high_wall_inner_corner.sw",
+}
+
+tile{
+  layer = 1,
+  x = 288,
+  y = 208,
+  width = 24,
+  height = 24,
+  pattern = "high_wall_inner_corner.se",
+}
+
+tile{
+  layer = 1,
+  x = 288,
+  y = 8,
+  width = 24,
+  height = 24,
+  pattern = "high_wall_inner_corner.ne",
+}
+
+tile{
+  layer = 1,
+  x = 192,
+  y = 8,
+  width = 96,
+  height = 24,
+  pattern = "high_wall.n",
+}
+
+tile{
+  layer = 1,
+  x = 8,
+  y = 144,
+  width = 24,
+  height = 64,
+  pattern = "high_wall.w",
+}
+
+tile{
+  layer = 1,
+  x = 8,
+  y = 32,
+  width = 24,
+  height = 64,
+  pattern = "high_wall.w",
+}
+
+tile{
+  layer = 1,
+  x = 288,
+  y = 32,
+  width = 24,
+  height = 64,
+  pattern = "high_wall.e",
+}
+
+tile{
+  layer = 1,
+  x = 288,
+  y = 144,
+  width = 24,
+  height = 64,
+  pattern = "high_wall.e",
+}
+
+tile{
+  layer = 1,
+  x = 128,
+  y = 176,
+  width = 32,
+  height = 24,
+  pattern = "entrance_floor.1.3",
+}
+
+tile{
+  layer = 1,
+  x = 160,
+  y = 176,
+  width = 32,
+  height = 24,
+  pattern = "entrance_floor.1.4",
 }
 
 dynamic_tile{
@@ -309,4 +417,39 @@ tile{
   pattern = "closed_door_top.s",
 }
 
+tile{
+  layer = 2,
+  x = 0,
+  y = 8,
+  width = 8,
+  height = 224,
+  pattern = "ceiling",
+}
+
+tile{
+  layer = 2,
+  x = 0,
+  y = 232,
+  width = 320,
+  height = 8,
+  pattern = "ceiling",
+}
+
+tile{
+  layer = 2,
+  x = 312,
+  y = 8,
+  width = 8,
+  height = 224,
+  pattern = "ceiling",
+}
+
+tile{
+  layer = 2,
+  x = 0,
+  y = 0,
+  width = 320,
+  height = 8,
+  pattern = "ceiling",
+}
 

--- a/data/maps/components/door/door_entrance_s_002777_6.dat
+++ b/data/maps/components/door/door_entrance_s_002777_6.dat
@@ -11,6 +11,186 @@ properties{
 
 tile{
   layer = 1,
+  x = 24,
+  y = 24,
+  width = 272,
+  height = 192,
+  pattern = "placeholder.floor.high",
+}
+
+tile{
+  layer = 1,
+  x = 8,
+  y = 8,
+  width = 24,
+  height = 24,
+  pattern = "high_wall_inner_corner.nw",
+}
+
+tile{
+  layer = 1,
+  x = 288,
+  y = 8,
+  width = 24,
+  height = 24,
+  pattern = "high_wall_inner_corner.ne",
+}
+
+tile{
+  layer = 1,
+  x = 8,
+  y = 208,
+  width = 24,
+  height = 24,
+  pattern = "high_wall_inner_corner.sw",
+}
+
+tile{
+  layer = 1,
+  x = 288,
+  y = 208,
+  width = 24,
+  height = 24,
+  pattern = "high_wall_inner_corner.se",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 8,
+  width = 96,
+  height = 24,
+  pattern = "high_wall.n",
+}
+
+tile{
+  layer = 1,
+  x = 192,
+  y = 8,
+  width = 96,
+  height = 24,
+  pattern = "high_wall.n",
+}
+
+tile{
+  layer = 1,
+  x = 8,
+  y = 144,
+  width = 24,
+  height = 64,
+  pattern = "high_wall.w",
+}
+
+tile{
+  layer = 1,
+  x = 8,
+  y = 32,
+  width = 24,
+  height = 64,
+  pattern = "high_wall.w",
+}
+
+tile{
+  layer = 1,
+  x = 288,
+  y = 32,
+  width = 24,
+  height = 64,
+  pattern = "high_wall.e",
+}
+
+tile{
+  layer = 1,
+  x = 288,
+  y = 144,
+  width = 24,
+  height = 64,
+  pattern = "high_wall.e",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 208,
+  width = 256,
+  height = 24,
+  pattern = "high_wall.s",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 32,
+  width = 256,
+  height = 8,
+  pattern = "wall_border.high.n",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 200,
+  width = 256,
+  height = 8,
+  pattern = "wall_border.high.s",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 32,
+  width = 8,
+  height = 176,
+  pattern = "wall_border.high.w",
+}
+
+tile{
+  layer = 1,
+  x = 280,
+  y = 32,
+  width = 8,
+  height = 176,
+  pattern = "wall_border.high.e",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 32,
+  width = 8,
+  height = 8,
+  pattern = "wall_border_inner_corner.high.nw",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 200,
+  width = 8,
+  height = 8,
+  pattern = "wall_border_inner_corner.high.sw",
+}
+
+tile{
+  layer = 1,
+  x = 280,
+  y = 200,
+  width = 8,
+  height = 8,
+  pattern = "wall_border_inner_corner.high.se",
+}
+
+tile{
+  layer = 1,
+  x = 280,
+  y = 32,
+  width = 8,
+  height = 8,
+  pattern = "wall_border_inner_corner.high.ne",
+}
+
+tile{
+  layer = 1,
   x = 120,
   y = 168,
   width = 80,
@@ -43,6 +223,24 @@ tile{
   width = 8,
   height = 8,
   pattern = "placeholder.barrier.2",
+}
+
+tile{
+  layer = 1,
+  x = 128,
+  y = 176,
+  width = 32,
+  height = 24,
+  pattern = "entrance_floor.1.3",
+}
+
+tile{
+  layer = 1,
+  x = 160,
+  y = 176,
+  width = 32,
+  height = 24,
+  pattern = "entrance_floor.1.4",
 }
 
 dynamic_tile{
@@ -251,6 +449,42 @@ dynamic_tile{
 
 tile{
   layer = 2,
+  x = 0,
+  y = 0,
+  width = 320,
+  height = 8,
+  pattern = "ceiling",
+}
+
+tile{
+  layer = 2,
+  x = 0,
+  y = 232,
+  width = 320,
+  height = 8,
+  pattern = "ceiling",
+}
+
+tile{
+  layer = 2,
+  x = 312,
+  y = 8,
+  width = 8,
+  height = 224,
+  pattern = "ceiling",
+}
+
+tile{
+  layer = 2,
+  x = 0,
+  y = 8,
+  width = 8,
+  height = 224,
+  pattern = "ceiling",
+}
+
+tile{
+  layer = 2,
   x = 136,
   y = 224,
   width = 48,
@@ -266,5 +500,4 @@ tile{
   height = 8,
   pattern = "closed_door_top.s",
 }
-
 

--- a/data/maps/components/door/door_exit_n_200000_1.dat
+++ b/data/maps/components/door/door_exit_n_200000_1.dat
@@ -11,6 +11,15 @@ properties{
 
 tile{
   layer = 1,
+  x = 144,
+  y = 8,
+  width = 32,
+  height = 24,
+  pattern = "high_wall.n",
+}
+
+tile{
+  layer = 1,
   x = 168,
   y = 16,
   width = 8,
@@ -55,22 +64,22 @@ tile{
 }
 
 sensor{
+  name = "sensor",
   layer = 1,
   x = 8,
   y = 13,
   width = 16,
   height = 16,
-  name = "sensor",
 }
 
 dynamic_tile{
+  name = "door_open",
   layer = 1,
   x = 152,
   y = 16,
+  pattern = "wall_stairs_curved.up.n",
   width = 16,
   height = 16,
-  name = "door_open",
-  pattern = "wall_stairs_curved.up.n",
   enabled_at_start = true,
 }
 
@@ -84,21 +93,21 @@ wall{
 }
 
 stairs{
+  name = "stairs",
   layer = 1,
   x = 152,
   y = 8,
-  name = "stairs",
   direction = 1,
-  subtype = "0",
+  subtype = 0,
 }
 
 sensor{
+  name = "entering",
   layer = 1,
   x = 8,
   y = 29,
   width = 16,
   height = 16,
-  name = "entering",
 }
 
 tile{
@@ -118,5 +127,4 @@ tile{
   height = 8,
   pattern = "closed_door_top.n",
 }
-
 

--- a/data/maps/components/door/door_open_e_010000_1.dat
+++ b/data/maps/components/door/door_open_e_010000_1.dat
@@ -73,12 +73,12 @@ wall{
 }
 
 sensor{
+  name = "sensor",
   layer = 1,
   x = 280,
   y = 125,
   width = 16,
   height = 16,
-  name = "sensor",
 }
 
 tile{
@@ -98,5 +98,4 @@ tile{
   height = 32,
   pattern = "open_door_top.low.e",
 }
-
 

--- a/data/maps/components/door/door_open_n_200000_1.dat
+++ b/data/maps/components/door/door_open_n_200000_1.dat
@@ -11,6 +11,15 @@ properties{
 
 tile{
   layer = 1,
+  x = 144,
+  y = 8,
+  width = 32,
+  height = 24,
+  pattern = "high_wall.n",
+}
+
+tile{
+  layer = 1,
   x = 152,
   y = 16,
   width = 16,
@@ -73,12 +82,12 @@ wall{
 }
 
 sensor{
+  name = "sensor",
   layer = 1,
   x = 160,
   y = 45,
   width = 16,
   height = 16,
-  name = "sensor",
 }
 
 tile{
@@ -98,5 +107,4 @@ tile{
   height = 8,
   pattern = "open_door_top.low.n",
 }
-
 

--- a/data/maps/components/door/door_open_s_002000_1.dat
+++ b/data/maps/components/door/door_open_s_002000_1.dat
@@ -11,6 +11,15 @@ properties{
 
 tile{
   layer = 1,
+  x = 144,
+  y = 208,
+  width = 32,
+  height = 24,
+  pattern = "high_wall.s",
+}
+
+tile{
+  layer = 1,
   x = 152,
   y = 208,
   width = 16,
@@ -73,12 +82,12 @@ wall{
 }
 
 sensor{
+  name = "sensor",
   layer = 1,
   x = 160,
   y = 205,
   width = 16,
   height = 16,
-  name = "sensor",
 }
 
 tile{
@@ -98,5 +107,4 @@ tile{
   height = 8,
   pattern = "open_door_top.low.s",
 }
-
 

--- a/data/maps/components/door/door_open_w_040000_1.dat
+++ b/data/maps/components/door/door_open_w_040000_1.dat
@@ -73,12 +73,12 @@ wall{
 }
 
 sensor{
+  name = "sensor",
   layer = 1,
   x = 40,
   y = 125,
   width = 16,
   height = 16,
-  name = "sensor",
 }
 
 tile{
@@ -98,5 +98,4 @@ tile{
   height = 32,
   pattern = "open_door_top.low.w",
 }
-
 

--- a/data/maps/components/door/door_smallkey_n_200000_1.dat
+++ b/data/maps/components/door/door_smallkey_n_200000_1.dat
@@ -11,6 +11,15 @@ properties{
 
 tile{
   layer = 1,
+  x = 144,
+  y = 8,
+  width = 32,
+  height = 24,
+  pattern = "high_wall.n",
+}
+
+tile{
+  layer = 1,
   x = 168,
   y = 16,
   width = 8,
@@ -55,13 +64,13 @@ tile{
 }
 
 dynamic_tile{
+  name = "door_open",
   layer = 1,
   x = 152,
   y = 16,
+  pattern = "door_floor.n",
   width = 16,
   height = 16,
-  name = "door_open",
-  pattern = "door_floor.n",
   enabled_at_start = true,
 }
 
@@ -75,12 +84,12 @@ wall{
 }
 
 sensor{
+  name = "sensor",
   layer = 1,
   x = 160,
   y = 45,
   width = 16,
   height = 16,
-  name = "sensor",
 }
 
 tile{
@@ -100,5 +109,4 @@ tile{
   height = 8,
   pattern = "closed_door_top.n",
 }
-
 

--- a/data/maps/components/door/door_smallkey_s_002000_1.dat
+++ b/data/maps/components/door/door_smallkey_s_002000_1.dat
@@ -11,6 +11,15 @@ properties{
 
 tile{
   layer = 1,
+  x = 144,
+  y = 208,
+  width = 32,
+  height = 24,
+  pattern = "high_wall.s",
+}
+
+tile{
+  layer = 1,
   x = 168,
   y = 208,
   width = 8,
@@ -55,13 +64,13 @@ tile{
 }
 
 dynamic_tile{
+  name = "door_open",
   layer = 1,
   x = 152,
   y = 208,
+  pattern = "door_floor.s",
   width = 16,
   height = 16,
-  name = "door_open",
-  pattern = "door_floor.s",
   enabled_at_start = true,
 }
 
@@ -75,12 +84,12 @@ wall{
 }
 
 sensor{
+  name = "sensor",
   layer = 1,
   x = 160,
   y = 205,
   width = 16,
   height = 16,
-  name = "sensor",
 }
 
 tile{
@@ -100,5 +109,4 @@ tile{
   height = 8,
   pattern = "closed_door_top.s",
 }
-
 

--- a/data/maps/components/enemy/enemy_boss_000777_1.dat
+++ b/data/maps/components/enemy/enemy_boss_000777_1.dat
@@ -11,28 +11,37 @@ properties{
 
 tile{
   layer = 1,
+  x = 56,
+  y = 24,
+  width = 208,
+  height = 192,
+  pattern = "placeholder.floor.high",
+}
+
+tile{
+  layer = 1,
   x = 256,
-  y = 8,
-  width = 56,
-  height = 224,
+  y = 0,
+  width = 64,
+  height = 240,
   pattern = "ceiling",
 }
 
 tile{
   layer = 1,
-  x = 8,
-  y = 8,
-  width = 56,
-  height = 224,
+  x = 0,
+  y = 0,
+  width = 64,
+  height = 240,
   pattern = "ceiling",
 }
 
 tile{
   layer = 1,
   x = 216,
-  y = 8,
+  y = 0,
   width = 40,
-  height = 40,
+  height = 48,
   pattern = "ceiling",
 }
 
@@ -41,7 +50,7 @@ tile{
   x = 216,
   y = 192,
   width = 40,
-  height = 40,
+  height = 48,
   pattern = "ceiling",
 }
 
@@ -50,16 +59,16 @@ tile{
   x = 64,
   y = 192,
   width = 40,
-  height = 40,
+  height = 48,
   pattern = "ceiling",
 }
 
 tile{
   layer = 1,
   x = 64,
-  y = 8,
+  y = 0,
   width = 40,
-  height = 40,
+  height = 48,
   pattern = "ceiling",
 }
 
@@ -657,47 +666,82 @@ tile{
   pattern = "wall_border.high.e",
 }
 
+tile{
+  layer = 1,
+  x = 112,
+  y = 32,
+  width = 96,
+  height = 8,
+  pattern = "wall_border.high.n",
+}
+
+tile{
+  layer = 1,
+  x = 112,
+  y = 200,
+  width = 96,
+  height = 8,
+  pattern = "wall_border.high.s",
+}
+
 enemy{
+  name = "agahnim",
   layer = 1,
   x = 160,
   y = 141,
-  name = "agahnim",
   direction = 3,
   breed = "agahnim",
   savegame_variable = "room_boss",
 }
 
 dynamic_tile{
+  name = "boss_2",
   layer = 1,
   x = 64,
   y = 96,
+  pattern = "placeholder.boss.1",
   width = 48,
   height = 48,
-  name = "boss_2",
-  pattern = "placeholder.boss.1",
   enabled_at_start = false,
 }
 
 dynamic_tile{
+  name = "boss_1",
   layer = 1,
   x = 136,
   y = 40,
+  pattern = "placeholder.boss.1",
   width = 48,
   height = 48,
-  name = "boss_1",
-  pattern = "placeholder.boss.1",
   enabled_at_start = false,
 }
 
 dynamic_tile{
+  name = "boss_3",
   layer = 1,
   x = 208,
   y = 96,
+  pattern = "placeholder.boss.1",
   width = 48,
   height = 48,
-  name = "boss_3",
-  pattern = "placeholder.boss.1",
   enabled_at_start = false,
 }
 
+tile{
+  layer = 2,
+  x = 104,
+  y = 232,
+  width = 112,
+  height = 8,
+  pattern = "ceiling",
+}
+
+tile{
+  layer = 2,
+  x = 104,
+  y = 0,
+  width = 112,
+  height = 8,
+  pattern = "ceiling",
+}
 

--- a/data/maps/components/enemy/enemy_boss_000777_3.dat
+++ b/data/maps/components/enemy/enemy_boss_000777_3.dat
@@ -10,28 +10,10 @@ properties{
 }
 
 tile{
-  layer = 1,
-  x = 272,
-  y = 32,
-  width = 24,
-  height = 176,
-  pattern = "high_wall.e",
-}
-
-tile{
-  layer = 1,
-  x = 248,
-  y = 32,
-  width = 24,
-  height = 176,
-  pattern = "hole",
-}
-
-tile{
-  layer = 1,
+  layer = 0,
   x = 48,
   y = 32,
-  width = 24,
+  width = 232,
   height = 176,
   pattern = "hole",
 }
@@ -39,10 +21,100 @@ tile{
 tile{
   layer = 1,
   x = 72,
-  y = 32,
+  y = 56,
   width = 64,
+  height = 112,
+  pattern = "placeholder.floor.high",
+}
+
+tile{
+  layer = 1,
+  x = 184,
+  y = 56,
+  width = 64,
+  height = 112,
+  pattern = "placeholder.floor.high",
+}
+
+tile{
+  layer = 1,
+  x = 136,
+  y = 24,
+  width = 48,
+  height = 64,
+  pattern = "placeholder.floor.high",
+}
+
+tile{
+  layer = 1,
+  x = 136,
+  y = 136,
+  width = 48,
+  height = 80,
+  pattern = "placeholder.floor.high",
+}
+
+tile{
+  layer = 1,
+  x = 48,
+  y = 8,
+  width = 80,
   height = 24,
-  pattern = "hole",
+  pattern = "high_wall.n",
+}
+
+tile{
+  layer = 1,
+  x = 192,
+  y = 8,
+  width = 80,
+  height = 24,
+  pattern = "high_wall.n",
+}
+
+tile{
+  layer = 1,
+  x = 48,
+  y = 208,
+  width = 80,
+  height = 24,
+  pattern = "high_wall.s",
+}
+
+tile{
+  layer = 1,
+  x = 192,
+  y = 208,
+  width = 80,
+  height = 24,
+  pattern = "high_wall.s",
+}
+
+tile{
+  layer = 1,
+  x = 144,
+  y = 32,
+  width = 32,
+  height = 8,
+  pattern = "wall_border.high.n",
+}
+
+tile{
+  layer = 1,
+  x = 144,
+  y = 200,
+  width = 32,
+  height = 8,
+  pattern = "wall_border.high.s",
+}
+
+tile{
+  layer = 1,
+  x = 272,
+  y = 32,
+  width = 24,
+  height = 176,
+  pattern = "high_wall.e",
 }
 
 tile{
@@ -88,33 +160,6 @@ tile{
   width = 16,
   height = 16,
   pattern = "chasm_wall_inner_corner.se",
-}
-
-tile{
-  layer = 1,
-  x = 184,
-  y = 32,
-  width = 64,
-  height = 24,
-  pattern = "hole",
-}
-
-tile{
-  layer = 1,
-  x = 72,
-  y = 168,
-  width = 64,
-  height = 40,
-  pattern = "hole",
-}
-
-tile{
-  layer = 1,
-  x = 184,
-  y = 168,
-  width = 64,
-  height = 40,
-  pattern = "hole",
 }
 
 tile{
@@ -389,15 +434,6 @@ tile{
 
 tile{
   layer = 1,
-  x = 136,
-  y = 88,
-  width = 48,
-  height = 48,
-  pattern = "hole",
-}
-
-tile{
-  layer = 1,
   x = 144,
   y = 88,
   width = 32,
@@ -549,9 +585,27 @@ enemy{
 
 tile{
   layer = 2,
-  x = 8,
+  x = 0,
+  y = 0,
+  width = 320,
+  height = 8,
+  pattern = "ceiling",
+}
+
+tile{
+  layer = 2,
+  x = 0,
+  y = 232,
+  width = 320,
+  height = 8,
+  pattern = "ceiling",
+}
+
+tile{
+  layer = 2,
+  x = 0,
   y = 8,
-  width = 16,
+  width = 24,
   height = 224,
   pattern = "ceiling",
 }
@@ -560,9 +614,8 @@ tile{
   layer = 2,
   x = 296,
   y = 8,
-  width = 16,
+  width = 24,
   height = 224,
   pattern = "ceiling",
 }
-
 

--- a/data/maps/components/enemy/enemy_fairy_000777_2.dat
+++ b/data/maps/components/enemy/enemy_fairy_000777_2.dat
@@ -11,6 +11,123 @@ properties{
 
 tile{
   layer = 1,
+  x = 24,
+  y = 24,
+  width = 272,
+  height = 192,
+  pattern = "placeholder.floor.high",
+}
+
+tile{
+  layer = 1,
+  x = 8,
+  y = 8,
+  width = 24,
+  height = 24,
+  pattern = "high_wall_inner_corner.nw",
+}
+
+tile{
+  layer = 1,
+  x = 288,
+  y = 8,
+  width = 24,
+  height = 24,
+  pattern = "high_wall_inner_corner.ne",
+}
+
+tile{
+  layer = 1,
+  x = 8,
+  y = 208,
+  width = 24,
+  height = 24,
+  pattern = "high_wall_inner_corner.sw",
+}
+
+tile{
+  layer = 1,
+  x = 288,
+  y = 208,
+  width = 24,
+  height = 24,
+  pattern = "high_wall_inner_corner.se",
+}
+
+tile{
+  layer = 1,
+  x = 48,
+  y = 32,
+  width = 224,
+  height = 8,
+  pattern = "wall_border.high.n",
+}
+
+tile{
+  layer = 1,
+  x = 48,
+  y = 200,
+  width = 224,
+  height = 8,
+  pattern = "wall_border.high.s",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 48,
+  width = 8,
+  height = 144,
+  pattern = "wall_border.high.w",
+}
+
+tile{
+  layer = 1,
+  x = 280,
+  y = 48,
+  width = 8,
+  height = 144,
+  pattern = "wall_border.high.e",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 32,
+  width = 8,
+  height = 8,
+  pattern = "wall_border_inner_corner.high.nw",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 200,
+  width = 8,
+  height = 8,
+  pattern = "wall_border_inner_corner.high.sw",
+}
+
+tile{
+  layer = 1,
+  x = 280,
+  y = 200,
+  width = 8,
+  height = 8,
+  pattern = "wall_border_inner_corner.high.se",
+}
+
+tile{
+  layer = 1,
+  x = 280,
+  y = 32,
+  width = 8,
+  height = 8,
+  pattern = "wall_border_inner_corner.high.ne",
+}
+
+tile{
+  layer = 1,
   x = 104,
   y = 80,
   width = 112,
@@ -110,24 +227,6 @@ tile{
 
 tile{
   layer = 1,
-  x = 8,
-  y = 48,
-  width = 24,
-  height = 16,
-  pattern = "high_wall.w",
-}
-
-tile{
-  layer = 1,
-  x = 48,
-  y = 8,
-  width = 16,
-  height = 24,
-  pattern = "high_wall.n",
-}
-
-tile{
-  layer = 1,
   x = 272,
   y = 16,
   width = 16,
@@ -263,60 +362,6 @@ tile{
 
 tile{
   layer = 1,
-  x = 288,
-  y = 48,
-  width = 24,
-  height = 16,
-  pattern = "high_wall.e",
-}
-
-tile{
-  layer = 1,
-  x = 256,
-  y = 8,
-  width = 16,
-  height = 24,
-  pattern = "high_wall.n",
-}
-
-tile{
-  layer = 1,
-  x = 8,
-  y = 176,
-  width = 24,
-  height = 16,
-  pattern = "high_wall.w",
-}
-
-tile{
-  layer = 1,
-  x = 288,
-  y = 176,
-  width = 24,
-  height = 16,
-  pattern = "high_wall.e",
-}
-
-tile{
-  layer = 1,
-  x = 48,
-  y = 208,
-  width = 16,
-  height = 24,
-  pattern = "high_wall.s",
-}
-
-tile{
-  layer = 1,
-  x = 256,
-  y = 208,
-  width = 16,
-  height = 24,
-  pattern = "high_wall.s",
-}
-
-tile{
-  layer = 1,
   x = 272,
   y = 192,
   width = 16,
@@ -387,6 +432,78 @@ tile{
   pattern = "shallow_water_border.s",
 }
 
+tile{
+  layer = 1,
+  x = 48,
+  y = 8,
+  width = 80,
+  height = 24,
+  pattern = "high_wall.n",
+}
+
+tile{
+  layer = 1,
+  x = 192,
+  y = 8,
+  width = 80,
+  height = 24,
+  pattern = "high_wall.n",
+}
+
+tile{
+  layer = 1,
+  x = 8,
+  y = 144,
+  width = 24,
+  height = 48,
+  pattern = "high_wall.w",
+}
+
+tile{
+  layer = 1,
+  x = 288,
+  y = 48,
+  width = 24,
+  height = 48,
+  pattern = "high_wall.e",
+}
+
+tile{
+  layer = 1,
+  x = 288,
+  y = 144,
+  width = 24,
+  height = 48,
+  pattern = "high_wall.e",
+}
+
+tile{
+  layer = 1,
+  x = 48,
+  y = 208,
+  width = 80,
+  height = 24,
+  pattern = "high_wall.s",
+}
+
+tile{
+  layer = 1,
+  x = 192,
+  y = 208,
+  width = 80,
+  height = 24,
+  pattern = "high_wall.s",
+}
+
+tile{
+  layer = 1,
+  x = 8,
+  y = 48,
+  width = 24,
+  height = 48,
+  pattern = "high_wall.w",
+}
+
 pickable{
   name = "fairy1_2",
   layer = 1,
@@ -409,6 +526,42 @@ pickable{
   x = 136,
   y = 133,
   treasure_name = "fairy",
+}
+
+tile{
+  layer = 2,
+  x = 0,
+  y = 0,
+  width = 320,
+  height = 8,
+  pattern = "ceiling",
+}
+
+tile{
+  layer = 2,
+  x = 0,
+  y = 232,
+  width = 320,
+  height = 8,
+  pattern = "ceiling",
+}
+
+tile{
+  layer = 2,
+  x = 312,
+  y = 8,
+  width = 8,
+  height = 224,
+  pattern = "ceiling",
+}
+
+tile{
+  layer = 2,
+  x = 0,
+  y = 8,
+  width = 8,
+  height = 224,
+  pattern = "ceiling",
 }
 
 tile{

--- a/data/maps/components/filler/filler_000001_1.dat
+++ b/data/maps/components/filler/filler_000001_1.dat
@@ -11,6 +11,15 @@ properties{
 
 tile{
   layer = 1,
+  x = 184,
+  y = 136,
+  width = 112,
+  height = 80,
+  pattern = "placeholder.floor.high",
+}
+
+tile{
+  layer = 1,
   x = 288,
   y = 144,
   width = 24,
@@ -108,4 +117,21 @@ tile{
   pattern = "ceiling",
 }
 
+tile{
+  layer = 2,
+  x = 184,
+  y = 232,
+  width = 32,
+  height = 8,
+  pattern = "ceiling",
+}
+
+tile{
+  layer = 2,
+  x = 312,
+  y = 136,
+  width = 8,
+  height = 32,
+  pattern = "ceiling",
+}
 

--- a/data/maps/components/filler/filler_000001_12.dat
+++ b/data/maps/components/filler/filler_000001_12.dat
@@ -11,6 +11,33 @@ properties{
 
 tile{
   layer = 1,
+  x = 184,
+  y = 136,
+  width = 112,
+  height = 80,
+  pattern = "placeholder.floor.high",
+}
+
+tile{
+  layer = 1,
+  x = 280,
+  y = 144,
+  width = 8,
+  height = 64,
+  pattern = "wall_border.high.e",
+}
+
+tile{
+  layer = 1,
+  x = 192,
+  y = 200,
+  width = 96,
+  height = 8,
+  pattern = "wall_border.high.s",
+}
+
+tile{
+  layer = 1,
   x = 224,
   y = 144,
   width = 48,
@@ -36,15 +63,68 @@ tile{
   pattern = "small_statue.1",
 }
 
+tile{
+  layer = 1,
+  x = 288,
+  y = 208,
+  width = 24,
+  height = 24,
+  pattern = "high_wall_inner_corner.se",
+}
+
+tile{
+  layer = 1,
+  x = 288,
+  y = 144,
+  width = 24,
+  height = 64,
+  pattern = "high_wall.e",
+}
+
+tile{
+  layer = 1,
+  x = 192,
+  y = 208,
+  width = 96,
+  height = 24,
+  pattern = "high_wall.s",
+}
+
+tile{
+  layer = 1,
+  x = 280,
+  y = 200,
+  width = 8,
+  height = 8,
+  pattern = "wall_border_inner_corner.high.se",
+}
+
 dynamic_tile{
+  name = "enemy_",
   layer = 1,
   x = 184,
   y = 152,
+  pattern = "placeholder.enemy",
   width = 32,
   height = 32,
-  name = "enemy_",
-  pattern = "placeholder.enemy",
   enabled_at_start = true,
 }
 
+tile{
+  layer = 2,
+  x = 184,
+  y = 232,
+  width = 136,
+  height = 8,
+  pattern = "ceiling",
+}
+
+tile{
+  layer = 2,
+  x = 312,
+  y = 136,
+  width = 8,
+  height = 96,
+  pattern = "ceiling",
+}
 

--- a/data/maps/components/filler/filler_000001_19.dat
+++ b/data/maps/components/filler/filler_000001_19.dat
@@ -11,6 +11,15 @@ properties{
 
 tile{
   layer = 1,
+  x = 184,
+  y = 136,
+  width = 112,
+  height = 80,
+  pattern = "placeholder.floor.high",
+}
+
+tile{
+  layer = 1,
   x = 192,
   y = 144,
   width = 80,
@@ -36,11 +45,64 @@ tile{
   pattern = "floor_torch.lit",
 }
 
+tile{
+  layer = 1,
+  x = 288,
+  y = 208,
+  width = 24,
+  height = 24,
+  pattern = "high_wall_inner_corner.se",
+}
+
+tile{
+  layer = 1,
+  x = 288,
+  y = 144,
+  width = 24,
+  height = 64,
+  pattern = "high_wall.e",
+}
+
+tile{
+  layer = 1,
+  x = 192,
+  y = 208,
+  width = 96,
+  height = 24,
+  pattern = "high_wall.s",
+}
+
+tile{
+  layer = 1,
+  x = 280,
+  y = 144,
+  width = 8,
+  height = 64,
+  pattern = "wall_border.high.e",
+}
+
+tile{
+  layer = 1,
+  x = 192,
+  y = 200,
+  width = 96,
+  height = 8,
+  pattern = "wall_border.high.s",
+}
+
+tile{
+  layer = 1,
+  x = 280,
+  y = 200,
+  width = 8,
+  height = 8,
+  pattern = "wall_border_inner_corner.high.se",
+}
+
 block{
   layer = 1,
   x = 216,
   y = 173,
-  direction = -1,
   sprite = "entities/statue",
   pushable = false,
   pullable = false,
@@ -48,14 +110,31 @@ block{
 }
 
 dynamic_tile{
+  name = "enemy_3",
   layer = 1,
   x = 256,
   y = 136,
+  pattern = "placeholder.enemy",
   width = 32,
   height = 32,
-  name = "enemy_3",
-  pattern = "placeholder.enemy",
   enabled_at_start = true,
 }
 
+tile{
+  layer = 2,
+  x = 184,
+  y = 232,
+  width = 136,
+  height = 8,
+  pattern = "ceiling",
+}
+
+tile{
+  layer = 2,
+  x = 312,
+  y = 136,
+  width = 8,
+  height = 96,
+  pattern = "ceiling",
+}
 

--- a/data/maps/components/filler/filler_000001_2.dat
+++ b/data/maps/components/filler/filler_000001_2.dat
@@ -11,6 +11,15 @@ properties{
 
 tile{
   layer = 1,
+  x = 184,
+  y = 136,
+  width = 112,
+  height = 80,
+  pattern = "placeholder.floor.high",
+}
+
+tile{
+  layer = 1,
   x = 248,
   y = 192,
   width = 40,
@@ -155,15 +164,6 @@ tile{
 
 tile{
   layer = 1,
-  x = 224,
-  y = 208,
-  width = 16,
-  height = 24,
-  pattern = "high_wall.s",
-}
-
-tile{
-  layer = 1,
   x = 240,
   y = 192,
   width = 16,
@@ -171,15 +171,59 @@ tile{
   pattern = "wall_border.high.se",
 }
 
+tile{
+  layer = 1,
+  x = 192,
+  y = 208,
+  width = 48,
+  height = 24,
+  pattern = "high_wall.s",
+}
+
+tile{
+  layer = 1,
+  x = 192,
+  y = 200,
+  width = 48,
+  height = 8,
+  pattern = "wall_border.high.s",
+}
+
+tile{
+  layer = 1,
+  x = 280,
+  y = 144,
+  width = 8,
+  height = 16,
+  pattern = "wall_border.high.e",
+}
+
 dynamic_tile{
+  name = "enemy_",
   layer = 1,
   x = 224,
   y = 144,
+  pattern = "placeholder.enemy",
   width = 32,
   height = 32,
-  name = "enemy_",
-  pattern = "placeholder.enemy",
   enabled_at_start = true,
 }
 
+tile{
+  layer = 2,
+  x = 184,
+  y = 232,
+  width = 136,
+  height = 8,
+  pattern = "ceiling",
+}
+
+tile{
+  layer = 2,
+  x = 312,
+  y = 136,
+  width = 8,
+  height = 96,
+  pattern = "ceiling",
+}
 

--- a/data/maps/components/filler/filler_000001_3.dat
+++ b/data/maps/components/filler/filler_000001_3.dat
@@ -11,6 +11,24 @@ properties{
 
 tile{
   layer = 1,
+  x = 184,
+  y = 136,
+  width = 112,
+  height = 80,
+  pattern = "placeholder.floor.high",
+}
+
+tile{
+  layer = 1,
+  x = 192,
+  y = 208,
+  width = 96,
+  height = 24,
+  pattern = "high_wall.s",
+}
+
+tile{
+  layer = 1,
   x = 224,
   y = 208,
   width = 32,
@@ -36,14 +54,59 @@ tile{
   pattern = "pedestal_torch_bottom",
 }
 
+tile{
+  layer = 1,
+  x = 288,
+  y = 208,
+  width = 24,
+  height = 24,
+  pattern = "high_wall_inner_corner.se",
+}
+
+tile{
+  layer = 1,
+  x = 288,
+  y = 144,
+  width = 24,
+  height = 64,
+  pattern = "high_wall.e",
+}
+
+tile{
+  layer = 1,
+  x = 192,
+  y = 200,
+  width = 96,
+  height = 8,
+  pattern = "wall_border.high.s",
+}
+
+tile{
+  layer = 1,
+  x = 280,
+  y = 144,
+  width = 8,
+  height = 64,
+  pattern = "wall_border.high.e",
+}
+
+tile{
+  layer = 1,
+  x = 280,
+  y = 200,
+  width = 8,
+  height = 8,
+  pattern = "wall_border_inner_corner.high.se",
+}
+
 dynamic_tile{
+  name = "enemy_1",
   layer = 1,
   x = 184,
   y = 136,
+  pattern = "placeholder.enemy",
   width = 32,
   height = 32,
-  name = "enemy_1",
-  pattern = "placeholder.enemy",
   enabled_at_start = true,
 }
 
@@ -65,4 +128,21 @@ tile{
   pattern = "pedestal_torch_top",
 }
 
+tile{
+  layer = 2,
+  x = 184,
+  y = 232,
+  width = 136,
+  height = 8,
+  pattern = "ceiling",
+}
+
+tile{
+  layer = 2,
+  x = 312,
+  y = 136,
+  width = 8,
+  height = 96,
+  pattern = "ceiling",
+}
 

--- a/data/maps/components/filler/filler_000001_statuestones.dat
+++ b/data/maps/components/filler/filler_000001_statuestones.dat
@@ -11,6 +11,15 @@ properties{
 
 tile{
   layer = 1,
+  x = 184,
+  y = 136,
+  width = 112,
+  height = 80,
+  pattern = "placeholder.floor.high",
+}
+
+tile{
+  layer = 1,
   x = 216,
   y = 152,
   width = 32,
@@ -18,48 +27,119 @@ tile{
   pattern = "placeholder.statue",
 }
 
-dynamic_tile{
+tile{
   layer = 1,
-  x = 200,
-  y = 152,
-  width = 16,
-  height = 16,
+  x = 288,
+  y = 208,
+  width = 24,
+  height = 24,
+  pattern = "high_wall_inner_corner.se",
+}
+
+tile{
+  layer = 1,
+  x = 288,
+  y = 144,
+  width = 24,
+  height = 64,
+  pattern = "high_wall.e",
+}
+
+tile{
+  layer = 1,
+  x = 192,
+  y = 208,
+  width = 96,
+  height = 24,
+  pattern = "high_wall.s",
+}
+
+tile{
+  layer = 1,
+  x = 192,
+  y = 200,
+  width = 96,
+  height = 8,
+  pattern = "wall_border.high.s",
+}
+
+tile{
+  layer = 1,
+  x = 280,
+  y = 144,
+  width = 8,
+  height = 64,
+  pattern = "wall_border.high.e",
+}
+
+tile{
+  layer = 1,
+  x = 280,
+  y = 200,
+  width = 8,
+  height = 8,
+  pattern = "wall_border_inner_corner.high.se",
+}
+
+dynamic_tile{
   name = "stone_9",
+  layer = 1,
+  x = 200,
+  y = 152,
   pattern = "placeholder.stone",
+  width = 16,
+  height = 16,
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "stone_2",
   layer = 1,
   x = 200,
   y = 168,
+  pattern = "placeholder.stone",
   width = 16,
   height = 16,
-  name = "stone_2",
-  pattern = "placeholder.stone",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "stone_3",
   layer = 1,
   x = 248,
   y = 168,
+  pattern = "placeholder.stone",
   width = 16,
   height = 16,
-  name = "stone_3",
-  pattern = "placeholder.stone",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "stone_4",
   layer = 1,
   x = 248,
   y = 152,
+  pattern = "placeholder.stone",
   width = 16,
   height = 16,
-  name = "stone_4",
-  pattern = "placeholder.stone",
   enabled_at_start = true,
 }
 
+tile{
+  layer = 2,
+  x = 184,
+  y = 232,
+  width = 136,
+  height = 8,
+  pattern = "ceiling",
+}
+
+tile{
+  layer = 2,
+  x = 312,
+  y = 136,
+  width = 8,
+  height = 96,
+  pattern = "ceiling",
+}
 

--- a/data/maps/components/filler/filler_000001_stones.dat
+++ b/data/maps/components/filler/filler_000001_stones.dat
@@ -9,81 +9,161 @@ properties{
   music = "same",
 }
 
-dynamic_tile{
+tile{
   layer = 1,
-  x = 216,
-  y = 152,
-  width = 16,
-  height = 16,
+  x = 184,
+  y = 136,
+  width = 112,
+  height = 80,
+  pattern = "placeholder.floor.high",
+}
+
+tile{
+  layer = 1,
+  x = 192,
+  y = 208,
+  width = 96,
+  height = 24,
+  pattern = "high_wall.s",
+}
+
+tile{
+  layer = 1,
+  x = 288,
+  y = 208,
+  width = 24,
+  height = 24,
+  pattern = "high_wall_inner_corner.se",
+}
+
+tile{
+  layer = 1,
+  x = 288,
+  y = 144,
+  width = 24,
+  height = 64,
+  pattern = "high_wall.e",
+}
+
+tile{
+  layer = 1,
+  x = 192,
+  y = 200,
+  width = 96,
+  height = 8,
+  pattern = "wall_border.high.s",
+}
+
+tile{
+  layer = 1,
+  x = 280,
+  y = 144,
+  width = 8,
+  height = 64,
+  pattern = "wall_border.high.e",
+}
+
+tile{
+  layer = 1,
+  x = 280,
+  y = 200,
+  width = 8,
+  height = 8,
+  pattern = "wall_border_inner_corner.high.se",
+}
+
+dynamic_tile{
   name = "stone_1",
+  layer = 1,
+  x = 216,
+  y = 152,
   pattern = "placeholder.stone",
+  width = 16,
+  height = 16,
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "stone_2",
   layer = 1,
   x = 232,
   y = 152,
+  pattern = "placeholder.stone",
   width = 16,
   height = 16,
-  name = "stone_2",
-  pattern = "placeholder.stone",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "stone_3",
   layer = 1,
   x = 248,
   y = 152,
+  pattern = "placeholder.stone",
   width = 16,
   height = 16,
-  name = "stone_3",
-  pattern = "placeholder.stone",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "stone_4",
   layer = 1,
   x = 216,
   y = 168,
+  pattern = "placeholder.stone",
   width = 16,
   height = 16,
-  name = "stone_4",
-  pattern = "placeholder.stone",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "stone_5",
   layer = 1,
   x = 232,
   y = 168,
+  pattern = "placeholder.stone",
   width = 16,
   height = 16,
-  name = "stone_5",
-  pattern = "placeholder.stone",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "stone_6",
   layer = 1,
   x = 248,
   y = 168,
+  pattern = "placeholder.stone",
   width = 16,
   height = 16,
-  name = "stone_6",
-  pattern = "placeholder.stone",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "enemy_2",
   layer = 1,
   x = 184,
   y = 152,
+  pattern = "placeholder.enemy",
   width = 32,
   height = 32,
-  name = "enemy_2",
-  pattern = "placeholder.enemy",
   enabled_at_start = true,
 }
 
+tile{
+  layer = 2,
+  x = 184,
+  y = 232,
+  width = 136,
+  height = 8,
+  pattern = "ceiling",
+}
+
+tile{
+  layer = 2,
+  x = 312,
+  y = 136,
+  width = 8,
+  height = 96,
+  pattern = "ceiling",
+}
 

--- a/data/maps/components/filler/filler_000002_empty.dat
+++ b/data/maps/components/filler/filler_000002_empty.dat
@@ -1,0 +1,37 @@
+properties{
+  x = 0,
+  y = 0,
+  width = 320,
+  height = 240,
+  min_layer = 0,
+  max_layer = 2,
+  tileset = "dungeon.tower_of_hera",
+}
+
+tile{
+  layer = 1,
+  x = 136,
+  y = 136,
+  width = 48,
+  height = 80,
+  pattern = "placeholder.floor.high",
+}
+
+tile{
+  layer = 1,
+  x = 144,
+  y = 200,
+  width = 32,
+  height = 8,
+  pattern = "wall_border.high.s",
+}
+
+tile{
+  layer = 2,
+  x = 136,
+  y = 232,
+  width = 48,
+  height = 8,
+  pattern = "ceiling",
+}
+

--- a/data/maps/components/filler/filler_000002_empty.lua
+++ b/data/maps/components/filler/filler_000002_empty.lua
@@ -1,0 +1,24 @@
+-- Lua script of map components/filler/filler_000020.
+-- This script is executed every time the hero enters this map.
+
+-- Feel free to modify the code below.
+-- You can add more events and remove the ones you don't need.
+
+-- See the Solarus Lua API documentation:
+-- http://www.solarus-games.org/doc/latest
+
+local map = ...
+local game = map:get_game()
+
+-- Event called at initialization time, as soon as this map becomes is loaded.
+function map:on_started()
+
+  -- You can initialize the movement and sprites of various
+  -- map entities here.
+end
+
+-- Event called after the opening transition effect of the map,
+-- that is, when the player takes control of the hero.
+function map:on_opening_transition_finished()
+
+end

--- a/data/maps/components/filler/filler_000004_12.dat
+++ b/data/maps/components/filler/filler_000004_12.dat
@@ -11,6 +11,15 @@ properties{
 
 tile{
   layer = 1,
+  x = 24,
+  y = 136,
+  width = 112,
+  height = 80,
+  pattern = "placeholder.floor.high",
+}
+
+tile{
+  layer = 1,
   x = 48,
   y = 144,
   width = 48,
@@ -36,15 +45,86 @@ tile{
   pattern = "small_statue.1",
 }
 
+tile{
+  layer = 1,
+  x = 8,
+  y = 208,
+  width = 24,
+  height = 24,
+  pattern = "high_wall_inner_corner.sw",
+}
+
+tile{
+  layer = 1,
+  x = 8,
+  y = 144,
+  width = 24,
+  height = 64,
+  pattern = "high_wall.w",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 208,
+  width = 96,
+  height = 24,
+  pattern = "high_wall.s",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 200,
+  width = 96,
+  height = 8,
+  pattern = "wall_border.high.s",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 144,
+  width = 8,
+  height = 64,
+  pattern = "wall_border.high.w",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 200,
+  width = 8,
+  height = 8,
+  pattern = "wall_border_inner_corner.high.sw",
+}
+
 dynamic_tile{
+  name = "enemy_",
   layer = 1,
   x = 104,
   y = 152,
+  pattern = "placeholder.enemy",
   width = 32,
   height = 32,
-  name = "enemy_",
-  pattern = "placeholder.enemy",
   enabled_at_start = true,
 }
 
+tile{
+  layer = 2,
+  x = 0,
+  y = 136,
+  width = 8,
+  height = 96,
+  pattern = "ceiling",
+}
+
+tile{
+  layer = 2,
+  x = 0,
+  y = 232,
+  width = 136,
+  height = 8,
+  pattern = "ceiling",
+}
 

--- a/data/maps/components/filler/filler_000004_2.dat
+++ b/data/maps/components/filler/filler_000004_2.dat
@@ -11,6 +11,15 @@ properties{
 
 tile{
   layer = 1,
+  x = 24,
+  y = 136,
+  width = 112,
+  height = 80,
+  pattern = "placeholder.floor.high",
+}
+
+tile{
+  layer = 1,
   x = 8,
   y = 168,
   width = 24,
@@ -112,7 +121,7 @@ tile{
   layer = 1,
   x = 80,
   y = 208,
-  width = 16,
+  width = 48,
   height = 24,
   pattern = "high_wall.s",
 }
@@ -171,15 +180,50 @@ tile{
   pattern = "wall_border.high.sw",
 }
 
+tile{
+  layer = 1,
+  x = 80,
+  y = 200,
+  width = 48,
+  height = 8,
+  pattern = "wall_border.high.s",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 144,
+  width = 8,
+  height = 16,
+  pattern = "wall_border.high.w",
+}
+
 dynamic_tile{
+  name = "enemy_",
   layer = 1,
   x = 64,
   y = 144,
+  pattern = "placeholder.enemy",
   width = 32,
   height = 32,
-  name = "enemy_",
-  pattern = "placeholder.enemy",
   enabled_at_start = true,
 }
 
+tile{
+  layer = 2,
+  x = 0,
+  y = 136,
+  width = 8,
+  height = 96,
+  pattern = "ceiling",
+}
+
+tile{
+  layer = 2,
+  x = 0,
+  y = 232,
+  width = 136,
+  height = 8,
+  pattern = "ceiling",
+}
 

--- a/data/maps/components/filler/filler_000004_3.dat
+++ b/data/maps/components/filler/filler_000004_3.dat
@@ -11,6 +11,42 @@ properties{
 
 tile{
   layer = 1,
+  x = 24,
+  y = 136,
+  width = 112,
+  height = 80,
+  pattern = "placeholder.floor.high",
+}
+
+tile{
+  layer = 1,
+  x = 8,
+  y = 208,
+  width = 24,
+  height = 24,
+  pattern = "high_wall_inner_corner.sw",
+}
+
+tile{
+  layer = 1,
+  x = 8,
+  y = 144,
+  width = 24,
+  height = 64,
+  pattern = "high_wall.w",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 208,
+  width = 96,
+  height = 24,
+  pattern = "high_wall.s",
+}
+
+tile{
+  layer = 1,
   x = 56,
   y = 168,
   width = 16,
@@ -36,14 +72,41 @@ tile{
   pattern = "placeholder.wall_statue.s",
 }
 
+tile{
+  layer = 1,
+  x = 32,
+  y = 200,
+  width = 96,
+  height = 8,
+  pattern = "wall_border.high.s",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 144,
+  width = 8,
+  height = 64,
+  pattern = "wall_border.high.w",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 200,
+  width = 8,
+  height = 8,
+  pattern = "wall_border_inner_corner.high.sw",
+}
+
 dynamic_tile{
+  name = "enemy_",
   layer = 1,
   x = 104,
   y = 136,
+  pattern = "placeholder.enemy",
   width = 32,
   height = 32,
-  name = "enemy_",
-  pattern = "placeholder.enemy",
   enabled_at_start = true,
 }
 
@@ -65,4 +128,21 @@ tile{
   pattern = "pedestal_torch_top",
 }
 
+tile{
+  layer = 2,
+  x = 0,
+  y = 136,
+  width = 8,
+  height = 96,
+  pattern = "ceiling",
+}
+
+tile{
+  layer = 2,
+  x = 0,
+  y = 232,
+  width = 136,
+  height = 8,
+  pattern = "ceiling",
+}
 

--- a/data/maps/components/filler/filler_000004_stones.dat
+++ b/data/maps/components/filler/filler_000004_stones.dat
@@ -9,81 +9,161 @@ properties{
   music = "same",
 }
 
-dynamic_tile{
+tile{
   layer = 1,
-  x = 72,
-  y = 152,
-  width = 16,
-  height = 16,
+  x = 24,
+  y = 136,
+  width = 112,
+  height = 80,
+  pattern = "placeholder.floor.high",
+}
+
+tile{
+  layer = 1,
+  x = 8,
+  y = 208,
+  width = 24,
+  height = 24,
+  pattern = "high_wall_inner_corner.sw",
+}
+
+tile{
+  layer = 1,
+  x = 8,
+  y = 144,
+  width = 24,
+  height = 64,
+  pattern = "high_wall.w",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 208,
+  width = 96,
+  height = 24,
+  pattern = "high_wall.s",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 200,
+  width = 96,
+  height = 8,
+  pattern = "wall_border.high.s",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 144,
+  width = 8,
+  height = 64,
+  pattern = "wall_border.high.w",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 200,
+  width = 8,
+  height = 8,
+  pattern = "wall_border_inner_corner.high.sw",
+}
+
+dynamic_tile{
   name = "stone_9",
+  layer = 1,
+  x = 72,
+  y = 152,
   pattern = "placeholder.stone",
+  width = 16,
+  height = 16,
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "stone_2",
   layer = 1,
   x = 88,
   y = 152,
+  pattern = "placeholder.stone",
   width = 16,
   height = 16,
-  name = "stone_2",
-  pattern = "placeholder.stone",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "stone_4",
   layer = 1,
   x = 72,
   y = 168,
+  pattern = "placeholder.stone",
   width = 16,
   height = 16,
-  name = "stone_4",
-  pattern = "placeholder.stone",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "stone_5",
   layer = 1,
   x = 88,
   y = 168,
+  pattern = "placeholder.stone",
   width = 16,
   height = 16,
-  name = "stone_5",
-  pattern = "placeholder.stone",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "stone_7",
   layer = 1,
   x = 56,
   y = 152,
+  pattern = "placeholder.stone",
   width = 16,
   height = 16,
-  name = "stone_7",
-  pattern = "placeholder.stone",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "stone_8",
   layer = 1,
   x = 56,
   y = 168,
+  pattern = "placeholder.stone",
   width = 16,
   height = 16,
-  name = "stone_8",
-  pattern = "placeholder.stone",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "enemy_1",
   layer = 1,
   x = 104,
   y = 152,
+  pattern = "placeholder.enemy",
   width = 32,
   height = 32,
-  name = "enemy_1",
-  pattern = "placeholder.enemy",
   enabled_at_start = true,
 }
 
+tile{
+  layer = 2,
+  x = 0,
+  y = 136,
+  width = 8,
+  height = 96,
+  pattern = "ceiling",
+}
+
+tile{
+  layer = 2,
+  x = 0,
+  y = 232,
+  width = 136,
+  height = 8,
+  pattern = "ceiling",
+}
 

--- a/data/maps/components/filler/filler_000004_torchstone.dat
+++ b/data/maps/components/filler/filler_000004_torchstone.dat
@@ -11,6 +11,24 @@ properties{
 
 tile{
   layer = 1,
+  x = 24,
+  y = 136,
+  width = 112,
+  height = 80,
+  pattern = "placeholder.floor.high",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 200,
+  width = 96,
+  height = 8,
+  pattern = "wall_border.high.s",
+}
+
+tile{
+  layer = 1,
   x = 56,
   y = 168,
   width = 16,
@@ -27,37 +45,99 @@ tile{
   pattern = "floor_torch.lit",
 }
 
+tile{
+  layer = 1,
+  x = 8,
+  y = 208,
+  width = 24,
+  height = 24,
+  pattern = "high_wall_inner_corner.sw",
+}
+
+tile{
+  layer = 1,
+  x = 8,
+  y = 144,
+  width = 24,
+  height = 64,
+  pattern = "high_wall.w",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 208,
+  width = 96,
+  height = 24,
+  pattern = "high_wall.s",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 144,
+  width = 8,
+  height = 64,
+  pattern = "wall_border.high.w",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 200,
+  width = 8,
+  height = 8,
+  pattern = "wall_border_inner_corner.high.sw",
+}
+
 dynamic_tile{
+  name = "stone_4",
   layer = 1,
   x = 72,
   y = 168,
+  pattern = "placeholder.stone",
   width = 16,
   height = 16,
-  name = "stone_4",
-  pattern = "placeholder.stone",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "stone_2",
   layer = 1,
   x = 56,
   y = 152,
+  pattern = "placeholder.stone",
   width = 16,
   height = 16,
-  name = "stone_2",
-  pattern = "placeholder.stone",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "enemy_2",
   layer = 1,
   x = 88,
   y = 152,
+  pattern = "placeholder.enemy",
   width = 32,
   height = 32,
-  name = "enemy_2",
-  pattern = "placeholder.enemy",
   enabled_at_start = true,
 }
 
+tile{
+  layer = 2,
+  x = 0,
+  y = 136,
+  width = 8,
+  height = 96,
+  pattern = "ceiling",
+}
+
+tile{
+  layer = 2,
+  x = 0,
+  y = 232,
+  width = 136,
+  height = 8,
+  pattern = "ceiling",
+}
 

--- a/data/maps/components/filler/filler_000007_1.dat
+++ b/data/maps/components/filler/filler_000007_1.dat
@@ -11,6 +11,51 @@ properties{
 
 tile{
   layer = 1,
+  x = 24,
+  y = 136,
+  width = 272,
+  height = 80,
+  pattern = "placeholder.floor.high",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 208,
+  width = 256,
+  height = 24,
+  pattern = "high_wall.s",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 200,
+  width = 32,
+  height = 8,
+  pattern = "wall_border.high.s",
+}
+
+tile{
+  layer = 1,
+  x = 256,
+  y = 200,
+  width = 32,
+  height = 8,
+  pattern = "wall_border.high.s",
+}
+
+tile{
+  layer = 1,
+  x = 128,
+  y = 200,
+  width = 64,
+  height = 8,
+  pattern = "wall_border.high.s",
+}
+
+tile{
+  layer = 1,
   x = 80,
   y = 160,
   width = 32,
@@ -333,70 +378,168 @@ tile{
   pattern = "ceiling",
 }
 
-dynamic_tile{
+tile{
   layer = 1,
-  x = 264,
-  y = 168,
-  width = 16,
-  height = 16,
+  x = 32,
+  y = 144,
+  width = 8,
+  height = 64,
+  pattern = "wall_border.high.w",
+}
+
+tile{
+  layer = 1,
+  x = 280,
+  y = 144,
+  width = 8,
+  height = 64,
+  pattern = "wall_border.high.e",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 200,
+  width = 8,
+  height = 8,
+  pattern = "wall_border_inner_corner.high.sw",
+}
+
+tile{
+  layer = 1,
+  x = 280,
+  y = 200,
+  width = 8,
+  height = 8,
+  pattern = "wall_border_inner_corner.high.se",
+}
+
+tile{
+  layer = 1,
+  x = 8,
+  y = 208,
+  width = 24,
+  height = 24,
+  pattern = "high_wall_inner_corner.sw",
+}
+
+tile{
+  layer = 1,
+  x = 288,
+  y = 208,
+  width = 24,
+  height = 24,
+  pattern = "high_wall_inner_corner.se",
+}
+
+tile{
+  layer = 1,
+  x = 8,
+  y = 144,
+  width = 24,
+  height = 64,
+  pattern = "high_wall.w",
+}
+
+tile{
+  layer = 1,
+  x = 288,
+  y = 144,
+  width = 24,
+  height = 64,
+  pattern = "high_wall.e",
+}
+
+dynamic_tile{
   name = "pot_1",
+  layer = 1,
+  x = 264,
+  y = 168,
   pattern = "placeholder.pot",
+  width = 16,
+  height = 16,
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "pot_2",
   layer = 1,
   x = 264,
   y = 184,
+  pattern = "placeholder.pot",
   width = 16,
   height = 16,
-  name = "pot_2",
-  pattern = "placeholder.pot",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "pot_3",
   layer = 1,
   x = 40,
   y = 168,
+  pattern = "placeholder.pot",
   width = 16,
   height = 16,
-  name = "pot_3",
-  pattern = "placeholder.pot",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "pot_4",
   layer = 1,
   x = 40,
   y = 184,
+  pattern = "placeholder.pot",
   width = 16,
   height = 16,
-  name = "pot_4",
-  pattern = "placeholder.pot",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "enemy_",
   layer = 1,
   x = 32,
   y = 136,
+  pattern = "placeholder.enemy",
   width = 32,
   height = 32,
-  name = "enemy_",
-  pattern = "placeholder.enemy",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "enemy_2",
   layer = 1,
   x = 256,
   y = 136,
+  pattern = "placeholder.enemy",
   width = 32,
   height = 32,
-  name = "enemy_2",
-  pattern = "placeholder.enemy",
   enabled_at_start = true,
 }
 
+tile{
+  layer = 2,
+  x = 0,
+  y = 136,
+  width = 8,
+  height = 96,
+  pattern = "ceiling",
+}
+
+tile{
+  layer = 2,
+  x = 0,
+  y = 232,
+  width = 320,
+  height = 8,
+  pattern = "ceiling",
+}
+
+tile{
+  layer = 2,
+  x = 312,
+  y = 136,
+  width = 8,
+  height = 96,
+  pattern = "ceiling",
+}
 

--- a/data/maps/components/filler/filler_000010_empty.dat
+++ b/data/maps/components/filler/filler_000010_empty.dat
@@ -1,0 +1,37 @@
+properties{
+  x = 0,
+  y = 0,
+  width = 320,
+  height = 240,
+  min_layer = 0,
+  max_layer = 2,
+  tileset = "dungeon.tower_of_hera",
+}
+
+tile{
+  layer = 1,
+  x = 184,
+  y = 104,
+  width = 112,
+  height = 32,
+  pattern = "placeholder.floor.high",
+}
+
+tile{
+  layer = 1,
+  x = 280,
+  y = 112,
+  width = 8,
+  height = 16,
+  pattern = "wall_border.high.e",
+}
+
+tile{
+  layer = 2,
+  x = 312,
+  y = 104,
+  width = 8,
+  height = 32,
+  pattern = "ceiling",
+}
+

--- a/data/maps/components/filler/filler_000010_empty.lua
+++ b/data/maps/components/filler/filler_000010_empty.lua
@@ -1,0 +1,24 @@
+-- Lua script of map components/filler/filler_000010_empty.
+-- This script is executed every time the hero enters this map.
+
+-- Feel free to modify the code below.
+-- You can add more events and remove the ones you don't need.
+
+-- See the Solarus Lua API documentation:
+-- http://www.solarus-games.org/doc/latest
+
+local map = ...
+local game = map:get_game()
+
+-- Event called at initialization time, as soon as this map becomes is loaded.
+function map:on_started()
+
+  -- You can initialize the movement and sprites of various
+  -- map entities here.
+end
+
+-- Event called after the opening transition effect of the map,
+-- that is, when the player takes control of the hero.
+function map:on_opening_transition_finished()
+
+end

--- a/data/maps/components/filler/filler_000020_1.dat
+++ b/data/maps/components/filler/filler_000020_1.dat
@@ -9,15 +9,23 @@ properties{
   music = "same",
 }
 
+tile{
+  layer = 1,
+  x = 136,
+  y = 104,
+  width = 48,
+  height = 32,
+  pattern = "placeholder.floor.high",
+}
+
 dynamic_tile{
+  name = "enemy_1",
   layer = 1,
   x = 144,
   y = 104,
+  pattern = "placeholder.enemy",
   width = 32,
   height = 32,
-  name = "enemy_1",
-  pattern = "placeholder.enemy",
   enabled_at_start = true,
 }
-
 

--- a/data/maps/components/filler/filler_000040_empty.dat
+++ b/data/maps/components/filler/filler_000040_empty.dat
@@ -1,0 +1,37 @@
+properties{
+  x = 0,
+  y = 0,
+  width = 320,
+  height = 240,
+  min_layer = 0,
+  max_layer = 2,
+  tileset = "dungeon.tower_of_hera",
+}
+
+tile{
+  layer = 1,
+  x = 24,
+  y = 104,
+  width = 112,
+  height = 32,
+  pattern = "placeholder.floor.high",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 112,
+  width = 8,
+  height = 16,
+  pattern = "wall_border.high.e",
+}
+
+tile{
+  layer = 2,
+  x = 0,
+  y = 104,
+  width = 8,
+  height = 32,
+  pattern = "ceiling",
+}
+

--- a/data/maps/components/filler/filler_000040_empty.lua
+++ b/data/maps/components/filler/filler_000040_empty.lua
@@ -1,0 +1,24 @@
+-- Lua script of map components/filler/filler_000040_empty.
+-- This script is executed every time the hero enters this map.
+
+-- Feel free to modify the code below.
+-- You can add more events and remove the ones you don't need.
+
+-- See the Solarus Lua API documentation:
+-- http://www.solarus-games.org/doc/latest
+
+local map = ...
+local game = map:get_game()
+
+-- Event called at initialization time, as soon as this map becomes is loaded.
+function map:on_started()
+
+  -- You can initialize the movement and sprites of various
+  -- map entities here.
+end
+
+-- Event called after the opening transition effect of the map,
+-- that is, when the player takes control of the hero.
+function map:on_opening_transition_finished()
+
+end

--- a/data/maps/components/filler/filler_000100_1.dat
+++ b/data/maps/components/filler/filler_000100_1.dat
@@ -11,6 +11,15 @@ properties{
 
 tile{
   layer = 1,
+  x = 184,
+  y = 24,
+  width = 112,
+  height = 80,
+  pattern = "placeholder.floor.high",
+}
+
+tile{
+  layer = 1,
   x = 192,
   y = 8,
   width = 24,
@@ -108,4 +117,21 @@ tile{
   pattern = "ceiling",
 }
 
+tile{
+  layer = 2,
+  x = 184,
+  y = 0,
+  width = 32,
+  height = 8,
+  pattern = "ceiling",
+}
+
+tile{
+  layer = 2,
+  x = 312,
+  y = 72,
+  width = 8,
+  height = 32,
+  pattern = "ceiling",
+}
 

--- a/data/maps/components/filler/filler_000100_12b.dat
+++ b/data/maps/components/filler/filler_000100_12b.dat
@@ -11,6 +11,33 @@ properties{
 
 tile{
   layer = 1,
+  x = 184,
+  y = 24,
+  width = 112,
+  height = 80,
+  pattern = "placeholder.floor.high",
+}
+
+tile{
+  layer = 1,
+  x = 192,
+  y = 32,
+  width = 64,
+  height = 8,
+  pattern = "wall_border.high.n",
+}
+
+tile{
+  layer = 1,
+  x = 280,
+  y = 64,
+  width = 8,
+  height = 32,
+  pattern = "wall_border.high.e",
+}
+
+tile{
+  layer = 1,
   x = 192,
   y = 48,
   width = 48,
@@ -144,15 +171,50 @@ tile{
   pattern = "floor_torch.lit",
 }
 
+tile{
+  layer = 1,
+  x = 192,
+  y = 8,
+  width = 64,
+  height = 24,
+  pattern = "high_wall.n",
+}
+
+tile{
+  layer = 1,
+  x = 288,
+  y = 64,
+  width = 24,
+  height = 32,
+  pattern = "high_wall.e",
+}
+
 dynamic_tile{
+  name = "enemy_",
   layer = 1,
   x = 192,
   y = 32,
+  pattern = "placeholder.enemy",
   width = 32,
   height = 32,
-  name = "enemy_",
-  pattern = "placeholder.enemy",
   enabled_at_start = true,
 }
 
+tile{
+  layer = 2,
+  x = 184,
+  y = 0,
+  width = 136,
+  height = 8,
+  pattern = "ceiling",
+}
+
+tile{
+  layer = 2,
+  x = 312,
+  y = 8,
+  width = 8,
+  height = 96,
+  pattern = "ceiling",
+}
 

--- a/data/maps/components/filler/filler_000100_6.dat
+++ b/data/maps/components/filler/filler_000100_6.dat
@@ -9,15 +9,95 @@ properties{
   music = "same",
 }
 
+tile{
+  layer = 1,
+  x = 184,
+  y = 24,
+  width = 112,
+  height = 80,
+  pattern = "placeholder.floor.high",
+}
+
+tile{
+  layer = 1,
+  x = 288,
+  y = 8,
+  width = 24,
+  height = 24,
+  pattern = "high_wall_inner_corner.ne",
+}
+
+tile{
+  layer = 1,
+  x = 192,
+  y = 8,
+  width = 96,
+  height = 24,
+  pattern = "high_wall.n",
+}
+
+tile{
+  layer = 1,
+  x = 288,
+  y = 32,
+  width = 24,
+  height = 64,
+  pattern = "high_wall.e",
+}
+
+tile{
+  layer = 1,
+  x = 192,
+  y = 32,
+  width = 96,
+  height = 8,
+  pattern = "wall_border.high.n",
+}
+
+tile{
+  layer = 1,
+  x = 280,
+  y = 32,
+  width = 8,
+  height = 64,
+  pattern = "wall_border.high.e",
+}
+
+tile{
+  layer = 1,
+  x = 280,
+  y = 32,
+  width = 8,
+  height = 8,
+  pattern = "wall_border_inner_corner.high.ne",
+}
+
 dynamic_tile{
+  name = "enemy_1",
   layer = 1,
   x = 232,
   y = 48,
+  pattern = "placeholder.enemy",
   width = 32,
   height = 32,
-  name = "enemy_1",
-  pattern = "placeholder.enemy",
   enabled_at_start = true,
 }
 
+tile{
+  layer = 2,
+  x = 184,
+  y = 0,
+  width = 136,
+  height = 8,
+  pattern = "ceiling",
+}
+
+tile{
+  layer = 2,
+  x = 312,
+  y = 8,
+  width = 8,
+  height = 96,
+  pattern = "ceiling",
+}
 

--- a/data/maps/components/filler/filler_000100_statuestones.dat
+++ b/data/maps/components/filler/filler_000100_statuestones.dat
@@ -11,6 +11,69 @@ properties{
 
 tile{
   layer = 1,
+  x = 184,
+  y = 24,
+  width = 112,
+  height = 80,
+  pattern = "placeholder.floor.high",
+}
+
+tile{
+  layer = 1,
+  x = 288,
+  y = 8,
+  width = 24,
+  height = 24,
+  pattern = "high_wall_inner_corner.ne",
+}
+
+tile{
+  layer = 1,
+  x = 288,
+  y = 32,
+  width = 24,
+  height = 64,
+  pattern = "high_wall.e",
+}
+
+tile{
+  layer = 1,
+  x = 192,
+  y = 8,
+  width = 96,
+  height = 24,
+  pattern = "high_wall.n",
+}
+
+tile{
+  layer = 1,
+  x = 192,
+  y = 32,
+  width = 96,
+  height = 8,
+  pattern = "wall_border.high.n",
+}
+
+tile{
+  layer = 1,
+  x = 280,
+  y = 32,
+  width = 8,
+  height = 64,
+  pattern = "wall_border.high.e",
+}
+
+tile{
+  layer = 1,
+  x = 280,
+  y = 32,
+  width = 8,
+  height = 8,
+  pattern = "wall_border_inner_corner.high.ne",
+}
+
+tile{
+  layer = 1,
   x = 216,
   y = 56,
   width = 32,
@@ -19,47 +82,64 @@ tile{
 }
 
 dynamic_tile{
-  layer = 1,
-  x = 200,
-  y = 56,
-  width = 16,
-  height = 16,
   name = "stone_5",
+  layer = 1,
+  x = 200,
+  y = 56,
   pattern = "placeholder.stone",
+  width = 16,
+  height = 16,
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "stone_2",
   layer = 1,
   x = 200,
   y = 72,
+  pattern = "placeholder.stone",
   width = 16,
   height = 16,
-  name = "stone_2",
-  pattern = "placeholder.stone",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "stone_3",
   layer = 1,
   x = 248,
   y = 72,
+  pattern = "placeholder.stone",
   width = 16,
   height = 16,
-  name = "stone_3",
-  pattern = "placeholder.stone",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "stone_4",
   layer = 1,
   x = 248,
   y = 56,
+  pattern = "placeholder.stone",
   width = 16,
   height = 16,
-  name = "stone_4",
-  pattern = "placeholder.stone",
   enabled_at_start = true,
 }
 
+tile{
+  layer = 2,
+  x = 184,
+  y = 0,
+  width = 136,
+  height = 8,
+  pattern = "ceiling",
+}
+
+tile{
+  layer = 2,
+  x = 312,
+  y = 8,
+  width = 8,
+  height = 96,
+  pattern = "ceiling",
+}
 

--- a/data/maps/components/filler/filler_000100_torchstones.dat
+++ b/data/maps/components/filler/filler_000100_torchstones.dat
@@ -11,6 +11,33 @@ properties{
 
 tile{
   layer = 1,
+  x = 184,
+  y = 24,
+  width = 112,
+  height = 80,
+  pattern = "placeholder.floor.high",
+}
+
+tile{
+  layer = 1,
+  x = 192,
+  y = 32,
+  width = 96,
+  height = 8,
+  pattern = "wall_border.high.n",
+}
+
+tile{
+  layer = 1,
+  x = 280,
+  y = 32,
+  width = 8,
+  height = 64,
+  pattern = "wall_border.high.e",
+}
+
+tile{
+  layer = 1,
   x = 248,
   y = 56,
   width = 16,
@@ -27,26 +54,79 @@ tile{
   pattern = "floor_torch.lit",
 }
 
+tile{
+  layer = 1,
+  x = 288,
+  y = 8,
+  width = 24,
+  height = 24,
+  pattern = "high_wall_inner_corner.ne",
+}
+
+tile{
+  layer = 1,
+  x = 192,
+  y = 8,
+  width = 96,
+  height = 24,
+  pattern = "high_wall.n",
+}
+
+tile{
+  layer = 1,
+  x = 288,
+  y = 32,
+  width = 24,
+  height = 64,
+  pattern = "high_wall.e",
+}
+
+tile{
+  layer = 1,
+  x = 280,
+  y = 32,
+  width = 8,
+  height = 8,
+  pattern = "wall_border_inner_corner.high.ne",
+}
+
 dynamic_tile{
+  name = "stone_4",
   layer = 1,
   x = 232,
   y = 56,
+  pattern = "placeholder.stone",
   width = 16,
   height = 16,
-  name = "stone_4",
-  pattern = "placeholder.stone",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "stone_2",
   layer = 1,
   x = 248,
   y = 72,
+  pattern = "placeholder.stone",
   width = 16,
   height = 16,
-  name = "stone_2",
-  pattern = "placeholder.stone",
   enabled_at_start = true,
 }
 
+tile{
+  layer = 2,
+  x = 184,
+  y = 0,
+  width = 136,
+  height = 8,
+  pattern = "ceiling",
+}
+
+tile{
+  layer = 2,
+  x = 312,
+  y = 8,
+  width = 8,
+  height = 96,
+  pattern = "ceiling",
+}
 

--- a/data/maps/components/filler/filler_000200_empty.dat
+++ b/data/maps/components/filler/filler_000200_empty.dat
@@ -1,0 +1,37 @@
+properties{
+  x = 0,
+  y = 0,
+  width = 320,
+  height = 240,
+  min_layer = 0,
+  max_layer = 2,
+  tileset = "dungeon.tower_of_hera",
+}
+
+tile{
+  layer = 1,
+  x = 136,
+  y = 24,
+  width = 48,
+  height = 80,
+  pattern = "placeholder.floor.high",
+}
+
+tile{
+  layer = 1,
+  x = 144,
+  y = 32,
+  width = 32,
+  height = 8,
+  pattern = "wall_border.high.n",
+}
+
+tile{
+  layer = 2,
+  x = 136,
+  y = 0,
+  width = 48,
+  height = 8,
+  pattern = "ceiling",
+}
+

--- a/data/maps/components/filler/filler_000200_empty.lua
+++ b/data/maps/components/filler/filler_000200_empty.lua
@@ -1,0 +1,24 @@
+-- Lua script of map components/filler/filler_000200_empty.
+-- This script is executed every time the hero enters this map.
+
+-- Feel free to modify the code below.
+-- You can add more events and remove the ones you don't need.
+
+-- See the Solarus Lua API documentation:
+-- http://www.solarus-games.org/doc/latest
+
+local map = ...
+local game = map:get_game()
+
+-- Event called at initialization time, as soon as this map becomes is loaded.
+function map:on_started()
+
+  -- You can initialize the movement and sprites of various
+  -- map entities here.
+end
+
+-- Event called after the opening transition effect of the map,
+-- that is, when the player takes control of the hero.
+function map:on_opening_transition_finished()
+
+end

--- a/data/maps/components/filler/filler_000400_19.dat
+++ b/data/maps/components/filler/filler_000400_19.dat
@@ -11,6 +11,15 @@ properties{
 
 tile{
   layer = 1,
+  x = 24,
+  y = 24,
+  width = 112,
+  height = 80,
+  pattern = "placeholder.floor.high",
+}
+
+tile{
+  layer = 1,
   x = 48,
   y = 48,
   width = 80,
@@ -36,11 +45,64 @@ tile{
   pattern = "floor_torch.lit",
 }
 
+tile{
+  layer = 1,
+  x = 8,
+  y = 8,
+  width = 24,
+  height = 24,
+  pattern = "high_wall_inner_corner.nw",
+}
+
+tile{
+  layer = 1,
+  x = 8,
+  y = 32,
+  width = 24,
+  height = 64,
+  pattern = "high_wall.w",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 8,
+  width = 96,
+  height = 24,
+  pattern = "high_wall.n",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 32,
+  width = 96,
+  height = 8,
+  pattern = "wall_border.high.n",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 32,
+  width = 8,
+  height = 64,
+  pattern = "wall_border.high.w",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 32,
+  width = 8,
+  height = 8,
+  pattern = "wall_border_inner_corner.high.nw",
+}
+
 block{
   layer = 1,
   x = 104,
   y = 77,
-  direction = -1,
   sprite = "entities/statue",
   pushable = false,
   pullable = false,
@@ -48,14 +110,31 @@ block{
 }
 
 dynamic_tile{
+  name = "enemy_",
   layer = 1,
   x = 32,
   y = 64,
+  pattern = "placeholder.enemy",
   width = 32,
   height = 32,
-  name = "enemy_",
-  pattern = "placeholder.enemy",
   enabled_at_start = true,
 }
 
+tile{
+  layer = 2,
+  x = 0,
+  y = 0,
+  width = 136,
+  height = 8,
+  pattern = "ceiling",
+}
+
+tile{
+  layer = 2,
+  x = 0,
+  y = 8,
+  width = 8,
+  height = 96,
+  pattern = "ceiling",
+}
 

--- a/data/maps/components/filler/filler_000400_statuestones.dat
+++ b/data/maps/components/filler/filler_000400_statuestones.dat
@@ -11,6 +11,15 @@ properties{
 
 tile{
   layer = 1,
+  x = 24,
+  y = 24,
+  width = 112,
+  height = 80,
+  pattern = "placeholder.floor.high",
+}
+
+tile{
+  layer = 1,
   x = 72,
   y = 56,
   width = 32,
@@ -18,48 +27,119 @@ tile{
   pattern = "placeholder.statue",
 }
 
-dynamic_tile{
+tile{
   layer = 1,
-  x = 56,
-  y = 56,
-  width = 16,
-  height = 16,
+  x = 8,
+  y = 8,
+  width = 24,
+  height = 24,
+  pattern = "high_wall_inner_corner.nw",
+}
+
+tile{
+  layer = 1,
+  x = 8,
+  y = 32,
+  width = 24,
+  height = 64,
+  pattern = "high_wall.w",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 8,
+  width = 96,
+  height = 24,
+  pattern = "high_wall.n",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 32,
+  width = 8,
+  height = 64,
+  pattern = "wall_border.high.w",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 32,
+  width = 96,
+  height = 8,
+  pattern = "wall_border.high.n",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 32,
+  width = 8,
+  height = 8,
+  pattern = "wall_border_inner_corner.high.nw",
+}
+
+dynamic_tile{
   name = "stone_5",
+  layer = 1,
+  x = 56,
+  y = 56,
   pattern = "placeholder.stone",
+  width = 16,
+  height = 16,
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "stone_2",
   layer = 1,
   x = 56,
   y = 72,
+  pattern = "placeholder.stone",
   width = 16,
   height = 16,
-  name = "stone_2",
-  pattern = "placeholder.stone",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "stone_3",
   layer = 1,
   x = 104,
   y = 72,
+  pattern = "placeholder.stone",
   width = 16,
   height = 16,
-  name = "stone_3",
-  pattern = "placeholder.stone",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "stone_4",
   layer = 1,
   x = 104,
   y = 56,
+  pattern = "placeholder.stone",
   width = 16,
   height = 16,
-  name = "stone_4",
-  pattern = "placeholder.stone",
   enabled_at_start = true,
 }
 
+tile{
+  layer = 2,
+  x = 0,
+  y = 8,
+  width = 8,
+  height = 96,
+  pattern = "ceiling",
+}
+
+tile{
+  layer = 2,
+  x = 0,
+  y = 0,
+  width = 136,
+  height = 8,
+  pattern = "ceiling",
+}
 

--- a/data/maps/components/filler/filler_000400_stones.dat
+++ b/data/maps/components/filler/filler_000400_stones.dat
@@ -9,81 +9,161 @@ properties{
   music = "same",
 }
 
-dynamic_tile{
+tile{
   layer = 1,
-  x = 72,
-  y = 56,
-  width = 16,
-  height = 16,
+  x = 24,
+  y = 24,
+  width = 112,
+  height = 80,
+  pattern = "placeholder.floor.high",
+}
+
+tile{
+  layer = 1,
+  x = 8,
+  y = 8,
+  width = 24,
+  height = 24,
+  pattern = "high_wall_inner_corner.nw",
+}
+
+tile{
+  layer = 1,
+  x = 8,
+  y = 32,
+  width = 24,
+  height = 64,
+  pattern = "high_wall.w",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 8,
+  width = 96,
+  height = 24,
+  pattern = "high_wall.n",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 32,
+  width = 96,
+  height = 8,
+  pattern = "wall_border.high.n",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 32,
+  width = 8,
+  height = 64,
+  pattern = "wall_border.high.w",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 32,
+  width = 8,
+  height = 8,
+  pattern = "wall_border_inner_corner.high.nw",
+}
+
+dynamic_tile{
   name = "stone_10",
+  layer = 1,
+  x = 72,
+  y = 56,
   pattern = "placeholder.stone",
+  width = 16,
+  height = 16,
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "stone_2",
   layer = 1,
   x = 88,
   y = 56,
+  pattern = "placeholder.stone",
   width = 16,
   height = 16,
-  name = "stone_2",
-  pattern = "placeholder.stone",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "stone_4",
   layer = 1,
   x = 72,
   y = 72,
+  pattern = "placeholder.stone",
   width = 16,
   height = 16,
-  name = "stone_4",
-  pattern = "placeholder.stone",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "stone_5",
   layer = 1,
   x = 88,
   y = 72,
+  pattern = "placeholder.stone",
   width = 16,
   height = 16,
-  name = "stone_5",
-  pattern = "placeholder.stone",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "stone_7",
   layer = 1,
   x = 56,
   y = 56,
+  pattern = "placeholder.stone",
   width = 16,
   height = 16,
-  name = "stone_7",
-  pattern = "placeholder.stone",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "stone_8",
   layer = 1,
   x = 56,
   y = 72,
+  pattern = "placeholder.stone",
   width = 16,
   height = 16,
-  name = "stone_8",
-  pattern = "placeholder.stone",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "enemy_2",
   layer = 1,
   x = 104,
   y = 56,
+  pattern = "placeholder.enemy",
   width = 32,
   height = 32,
-  name = "enemy_2",
-  pattern = "placeholder.enemy",
   enabled_at_start = true,
 }
 
+tile{
+  layer = 2,
+  x = 0,
+  y = 8,
+  width = 8,
+  height = 96,
+  pattern = "ceiling",
+}
+
+tile{
+  layer = 2,
+  x = 0,
+  y = 0,
+  width = 136,
+  height = 8,
+  pattern = "ceiling",
+}
 

--- a/data/maps/components/filler/filler_000400_torchstones.dat
+++ b/data/maps/components/filler/filler_000400_torchstones.dat
@@ -28,25 +28,24 @@ tile{
 }
 
 dynamic_tile{
+  name = "stone_3",
   layer = 1,
   x = 72,
   y = 56,
+  pattern = "placeholder.stone",
   width = 16,
   height = 16,
-  name = "stone_3",
-  pattern = "placeholder.stone",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "stone_2",
   layer = 1,
   x = 56,
   y = 72,
+  pattern = "placeholder.stone",
   width = 16,
   height = 16,
-  name = "stone_2",
-  pattern = "placeholder.stone",
   enabled_at_start = true,
 }
-
 

--- a/data/maps/components/filler/filler_000444_barrierstones.dat
+++ b/data/maps/components/filler/filler_000444_barrierstones.dat
@@ -11,6 +11,114 @@ properties{
 
 tile{
   layer = 1,
+  x = 24,
+  y = 24,
+  width = 112,
+  height = 192,
+  pattern = "placeholder.floor.high",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 32,
+  width = 8,
+  height = 176,
+  pattern = "wall_border.high.w",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 200,
+  width = 96,
+  height = 8,
+  pattern = "wall_border.high.s",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 32,
+  width = 96,
+  height = 8,
+  pattern = "wall_border.high.n",
+}
+
+tile{
+  layer = 1,
+  x = 8,
+  y = 8,
+  width = 24,
+  height = 24,
+  pattern = "high_wall_inner_corner.nw",
+}
+
+tile{
+  layer = 1,
+  x = 8,
+  y = 208,
+  width = 24,
+  height = 24,
+  pattern = "high_wall_inner_corner.sw",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 8,
+  width = 96,
+  height = 24,
+  pattern = "high_wall.n",
+}
+
+tile{
+  layer = 1,
+  x = 8,
+  y = 144,
+  width = 24,
+  height = 64,
+  pattern = "high_wall.w",
+}
+
+tile{
+  layer = 1,
+  x = 8,
+  y = 32,
+  width = 24,
+  height = 64,
+  pattern = "high_wall.w",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 208,
+  width = 96,
+  height = 24,
+  pattern = "high_wall.s",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 32,
+  width = 8,
+  height = 8,
+  pattern = "wall_border_inner_corner.high.nw",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 200,
+  width = 8,
+  height = 8,
+  pattern = "wall_border_inner_corner.high.sw",
+}
+
+tile{
+  layer = 1,
   x = 88,
   y = 72,
   width = 8,
@@ -37,69 +145,95 @@ tile{
 }
 
 dynamic_tile{
+  name = "stone_1",
   layer = 1,
   x = 72,
   y = 72,
+  pattern = "placeholder.stone",
   width = 16,
   height = 16,
-  name = "stone_1",
-  pattern = "placeholder.stone",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "stone_2",
   layer = 1,
   x = 72,
   y = 88,
+  pattern = "placeholder.stone",
   width = 16,
   height = 16,
-  name = "stone_2",
-  pattern = "placeholder.stone",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "stone_3",
   layer = 1,
   x = 72,
   y = 104,
+  pattern = "placeholder.stone",
   width = 16,
   height = 16,
-  name = "stone_3",
-  pattern = "placeholder.stone",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "stone_4",
   layer = 1,
   x = 72,
   y = 120,
+  pattern = "placeholder.stone",
   width = 16,
   height = 16,
-  name = "stone_4",
-  pattern = "placeholder.stone",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "stone_5",
   layer = 1,
   x = 72,
   y = 136,
+  pattern = "placeholder.stone",
   width = 16,
   height = 16,
-  name = "stone_5",
-  pattern = "placeholder.stone",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "stone_6",
   layer = 1,
   x = 72,
   y = 152,
+  pattern = "placeholder.stone",
   width = 16,
   height = 16,
-  name = "stone_6",
-  pattern = "placeholder.stone",
   enabled_at_start = true,
 }
 
+tile{
+  layer = 2,
+  x = 0,
+  y = 8,
+  width = 8,
+  height = 224,
+  pattern = "ceiling",
+}
+
+tile{
+  layer = 2,
+  x = 0,
+  y = 0,
+  width = 136,
+  height = 8,
+  pattern = "ceiling",
+}
+
+tile{
+  layer = 2,
+  x = 0,
+  y = 232,
+  width = 136,
+  height = 8,
+  pattern = "ceiling",
+}
 

--- a/data/maps/components/filler/filler_000777_10.dat
+++ b/data/maps/components/filler/filler_000777_10.dat
@@ -11,6 +11,15 @@ properties{
 
 tile{
   layer = 1,
+  x = 24,
+  y = 24,
+  width = 272,
+  height = 192,
+  pattern = "placeholder.floor.high",
+}
+
+tile{
+  layer = 1,
   x = 96,
   y = 64,
   width = 128,
@@ -198,114 +207,329 @@ tile{
   pattern = "placeholder.barrier.2",
 }
 
-dynamic_tile{
+tile{
   layer = 1,
-  x = 40,
-  y = 56,
-  width = 16,
-  height = 16,
+  x = 8,
+  y = 8,
+  width = 24,
+  height = 24,
+  pattern = "high_wall_inner_corner.nw",
+}
+
+tile{
+  layer = 1,
+  x = 288,
+  y = 8,
+  width = 24,
+  height = 24,
+  pattern = "high_wall_inner_corner.ne",
+}
+
+tile{
+  layer = 1,
+  x = 8,
+  y = 208,
+  width = 24,
+  height = 24,
+  pattern = "high_wall_inner_corner.sw",
+}
+
+tile{
+  layer = 1,
+  x = 288,
+  y = 208,
+  width = 24,
+  height = 24,
+  pattern = "high_wall_inner_corner.se",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 8,
+  width = 96,
+  height = 24,
+  pattern = "high_wall.n",
+}
+
+tile{
+  layer = 1,
+  x = 192,
+  y = 8,
+  width = 96,
+  height = 24,
+  pattern = "high_wall.n",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 208,
+  width = 96,
+  height = 24,
+  pattern = "high_wall.s",
+}
+
+tile{
+  layer = 1,
+  x = 192,
+  y = 208,
+  width = 96,
+  height = 24,
+  pattern = "high_wall.s",
+}
+
+tile{
+  layer = 1,
+  x = 8,
+  y = 32,
+  width = 24,
+  height = 64,
+  pattern = "high_wall.w",
+}
+
+tile{
+  layer = 1,
+  x = 8,
+  y = 144,
+  width = 24,
+  height = 64,
+  pattern = "high_wall.w",
+}
+
+tile{
+  layer = 1,
+  x = 288,
+  y = 32,
+  width = 24,
+  height = 64,
+  pattern = "high_wall.e",
+}
+
+tile{
+  layer = 1,
+  x = 288,
+  y = 144,
+  width = 24,
+  height = 64,
+  pattern = "high_wall.e",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 32,
+  width = 256,
+  height = 8,
+  pattern = "wall_border.high.n",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 200,
+  width = 256,
+  height = 8,
+  pattern = "wall_border.high.s",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 32,
+  width = 8,
+  height = 176,
+  pattern = "wall_border.high.w",
+}
+
+tile{
+  layer = 1,
+  x = 280,
+  y = 32,
+  width = 8,
+  height = 176,
+  pattern = "wall_border.high.e",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 32,
+  width = 8,
+  height = 8,
+  pattern = "wall_border_inner_corner.high.nw",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 200,
+  width = 8,
+  height = 8,
+  pattern = "wall_border_inner_corner.high.sw",
+}
+
+tile{
+  layer = 1,
+  x = 280,
+  y = 200,
+  width = 8,
+  height = 8,
+  pattern = "wall_border_inner_corner.high.se",
+}
+
+tile{
+  layer = 1,
+  x = 280,
+  y = 32,
+  width = 8,
+  height = 8,
+  pattern = "wall_border_inner_corner.high.ne",
+}
+
+dynamic_tile{
   name = "pot_9",
+  layer = 1,
+  x = 40,
+  y = 56,
   pattern = "placeholder.pot",
+  width = 16,
+  height = 16,
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "pot_2",
   layer = 1,
   x = 40,
   y = 72,
+  pattern = "placeholder.pot",
   width = 16,
   height = 16,
-  name = "pot_2",
-  pattern = "placeholder.pot",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "pot_3",
   layer = 1,
   x = 264,
   y = 72,
+  pattern = "placeholder.pot",
   width = 16,
   height = 16,
-  name = "pot_3",
-  pattern = "placeholder.pot",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "pot_4",
   layer = 1,
   x = 264,
   y = 56,
+  pattern = "placeholder.pot",
   width = 16,
   height = 16,
-  name = "pot_4",
-  pattern = "placeholder.pot",
   enabled_at_start = true,
 }
 
 dynamic_tile{
-  layer = 1,
-  x = 264,
-  y = 168,
-  width = 16,
-  height = 16,
   name = "pot_5",
+  layer = 1,
+  x = 264,
+  y = 168,
   pattern = "placeholder.pot",
+  width = 16,
+  height = 16,
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "pot_6",
   layer = 1,
   x = 264,
   y = 152,
+  pattern = "placeholder.pot",
   width = 16,
   height = 16,
-  name = "pot_6",
-  pattern = "placeholder.pot",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "pot_7",
   layer = 1,
   x = 40,
   y = 152,
+  pattern = "placeholder.pot",
   width = 16,
   height = 16,
-  name = "pot_7",
-  pattern = "placeholder.pot",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "pot_8",
   layer = 1,
   x = 40,
   y = 168,
+  pattern = "placeholder.pot",
   width = 16,
   height = 16,
-  name = "pot_8",
-  pattern = "placeholder.pot",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "enemy_3",
   layer = 1,
   x = 240,
   y = 104,
+  pattern = "placeholder.enemy",
   width = 32,
   height = 32,
-  name = "enemy_3",
-  pattern = "placeholder.enemy",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "enemy_2",
   layer = 1,
   x = 48,
   y = 104,
+  pattern = "placeholder.enemy",
   width = 32,
   height = 32,
-  name = "enemy_2",
-  pattern = "placeholder.enemy",
   enabled_at_start = true,
 }
 
+tile{
+  layer = 2,
+  x = 0,
+  y = 0,
+  width = 320,
+  height = 8,
+  pattern = "ceiling",
+}
+
+tile{
+  layer = 2,
+  x = 0,
+  y = 232,
+  width = 320,
+  height = 8,
+  pattern = "ceiling",
+}
+
+tile{
+  layer = 2,
+  x = 312,
+  y = 8,
+  width = 8,
+  height = 224,
+  pattern = "ceiling",
+}
+
+tile{
+  layer = 2,
+  x = 0,
+  y = 8,
+  width = 8,
+  height = 224,
+  pattern = "ceiling",
+}
 

--- a/data/maps/components/filler/filler_000777_3.dat
+++ b/data/maps/components/filler/filler_000777_3.dat
@@ -11,6 +11,123 @@ properties{
 
 tile{
   layer = 1,
+  x = 24,
+  y = 24,
+  width = 272,
+  height = 192,
+  pattern = "placeholder.floor.high",
+}
+
+tile{
+  layer = 1,
+  x = 8,
+  y = 8,
+  width = 24,
+  height = 24,
+  pattern = "high_wall_inner_corner.nw",
+}
+
+tile{
+  layer = 1,
+  x = 288,
+  y = 208,
+  width = 24,
+  height = 24,
+  pattern = "high_wall_inner_corner.se",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 8,
+  width = 96,
+  height = 24,
+  pattern = "high_wall.n",
+}
+
+tile{
+  layer = 1,
+  x = 8,
+  y = 32,
+  width = 24,
+  height = 64,
+  pattern = "high_wall.w",
+}
+
+tile{
+  layer = 1,
+  x = 288,
+  y = 144,
+  width = 24,
+  height = 64,
+  pattern = "high_wall.e",
+}
+
+tile{
+  layer = 1,
+  x = 192,
+  y = 208,
+  width = 96,
+  height = 24,
+  pattern = "high_wall.s",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 32,
+  width = 160,
+  height = 8,
+  pattern = "wall_border.high.n",
+}
+
+tile{
+  layer = 1,
+  x = 128,
+  y = 200,
+  width = 160,
+  height = 8,
+  pattern = "wall_border.high.s",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 32,
+  width = 8,
+  height = 112,
+  pattern = "wall_border.high.w",
+}
+
+tile{
+  layer = 1,
+  x = 280,
+  y = 96,
+  width = 8,
+  height = 112,
+  pattern = "wall_border.high.e",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 32,
+  width = 8,
+  height = 8,
+  pattern = "wall_border_inner_corner.high.nw",
+}
+
+tile{
+  layer = 1,
+  x = 280,
+  y = 200,
+  width = 8,
+  height = 8,
+  pattern = "wall_border_inner_corner.high.se",
+}
+
+tile{
+  layer = 1,
   x = 184,
   y = 32,
   width = 8,
@@ -370,36 +487,71 @@ tile{
 }
 
 dynamic_tile{
+  name = "enemy_1",
   layer = 1,
   x = 32,
   y = 88,
+  pattern = "placeholder.enemy",
   width = 32,
   height = 32,
-  name = "enemy_1",
-  pattern = "placeholder.enemy",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "enemy_2",
   layer = 1,
   x = 144,
   y = 104,
+  pattern = "placeholder.enemy",
   width = 32,
   height = 32,
-  name = "enemy_2",
-  pattern = "placeholder.enemy",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "enemy_3",
   layer = 1,
   x = 256,
   y = 120,
+  pattern = "placeholder.enemy",
   width = 32,
   height = 32,
-  name = "enemy_3",
-  pattern = "placeholder.enemy",
   enabled_at_start = true,
 }
 
+tile{
+  layer = 2,
+  x = 0,
+  y = 0,
+  width = 320,
+  height = 8,
+  pattern = "ceiling",
+}
+
+tile{
+  layer = 2,
+  x = 0,
+  y = 232,
+  width = 320,
+  height = 8,
+  pattern = "ceiling",
+}
+
+tile{
+  layer = 2,
+  x = 312,
+  y = 8,
+  width = 8,
+  height = 224,
+  pattern = "ceiling",
+}
+
+tile{
+  layer = 2,
+  x = 0,
+  y = 8,
+  width = 8,
+  height = 224,
+  pattern = "ceiling",
+}
 

--- a/data/maps/components/filler/filler_000777_4.dat
+++ b/data/maps/components/filler/filler_000777_4.dat
@@ -10,12 +10,66 @@ properties{
 }
 
 tile{
+  layer = 0,
+  x = 32,
+  y = 32,
+  width = 264,
+  height = 184,
+  pattern = "hole",
+}
+
+tile{
+  layer = 1,
+  x = 24,
+  y = 72,
+  width = 272,
+  height = 96,
+  pattern = "placeholder.floor.high",
+}
+
+tile{
+  layer = 1,
+  x = 72,
+  y = 24,
+  width = 176,
+  height = 192,
+  pattern = "placeholder.floor.high",
+}
+
+tile{
   layer = 1,
   x = 32,
-  y = 168,
-  width = 40,
-  height = 40,
-  pattern = "hole",
+  y = 8,
+  width = 96,
+  height = 24,
+  pattern = "high_wall.n",
+}
+
+tile{
+  layer = 1,
+  x = 192,
+  y = 8,
+  width = 96,
+  height = 24,
+  pattern = "high_wall.n",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 208,
+  width = 96,
+  height = 24,
+  pattern = "high_wall.s",
+}
+
+tile{
+  layer = 1,
+  x = 192,
+  y = 208,
+  width = 96,
+  height = 24,
+  pattern = "high_wall.s",
 }
 
 tile{
@@ -43,33 +97,6 @@ tile{
   width = 16,
   height = 24,
   pattern = "chasm_wall.w",
-}
-
-tile{
-  layer = 1,
-  x = 32,
-  y = 32,
-  width = 40,
-  height = 40,
-  pattern = "hole",
-}
-
-tile{
-  layer = 1,
-  x = 248,
-  y = 32,
-  width = 40,
-  height = 40,
-  pattern = "hole",
-}
-
-tile{
-  layer = 1,
-  x = 248,
-  y = 168,
-  width = 40,
-  height = 40,
-  pattern = "hole",
 }
 
 tile{
@@ -414,37 +441,180 @@ tile{
   pattern = "placeholder.big_barrier.2",
 }
 
+tile{
+  layer = 1,
+  x = 8,
+  y = 8,
+  width = 24,
+  height = 24,
+  pattern = "high_wall_inner_corner.nw",
+}
+
+tile{
+  layer = 1,
+  x = 288,
+  y = 8,
+  width = 24,
+  height = 24,
+  pattern = "high_wall_inner_corner.ne",
+}
+
+tile{
+  layer = 1,
+  x = 288,
+  y = 208,
+  width = 24,
+  height = 24,
+  pattern = "high_wall_inner_corner.se",
+}
+
+tile{
+  layer = 1,
+  x = 8,
+  y = 208,
+  width = 24,
+  height = 24,
+  pattern = "high_wall_inner_corner.sw",
+}
+
+tile{
+  layer = 1,
+  x = 8,
+  y = 144,
+  width = 24,
+  height = 64,
+  pattern = "high_wall.w",
+}
+
+tile{
+  layer = 1,
+  x = 8,
+  y = 32,
+  width = 24,
+  height = 64,
+  pattern = "high_wall.w",
+}
+
+tile{
+  layer = 1,
+  x = 288,
+  y = 32,
+  width = 24,
+  height = 64,
+  pattern = "high_wall.e",
+}
+
+tile{
+  layer = 1,
+  x = 288,
+  y = 144,
+  width = 24,
+  height = 64,
+  pattern = "high_wall.e",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 72,
+  width = 8,
+  height = 96,
+  pattern = "wall_border.high.w",
+}
+
+tile{
+  layer = 1,
+  x = 280,
+  y = 72,
+  width = 8,
+  height = 96,
+  pattern = "wall_border.high.e",
+}
+
+tile{
+  layer = 1,
+  x = 72,
+  y = 200,
+  width = 176,
+  height = 8,
+  pattern = "wall_border.high.s",
+}
+
+tile{
+  layer = 1,
+  x = 72,
+  y = 32,
+  width = 176,
+  height = 8,
+  pattern = "wall_border.high.n",
+}
+
 dynamic_tile{
+  name = "enemy_1",
   layer = 1,
   x = 40,
   y = 104,
+  pattern = "placeholder.enemy",
   width = 32,
   height = 32,
-  name = "enemy_1",
-  pattern = "placeholder.enemy",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "enemy_2",
   layer = 1,
   x = 248,
   y = 104,
+  pattern = "placeholder.enemy",
   width = 32,
   height = 32,
-  name = "enemy_2",
-  pattern = "placeholder.enemy",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "enemy_3",
   layer = 1,
   x = 144,
   y = 80,
+  pattern = "placeholder.enemy",
   width = 32,
   height = 32,
-  name = "enemy_3",
-  pattern = "placeholder.enemy",
   enabled_at_start = true,
 }
 
+tile{
+  layer = 2,
+  x = 0,
+  y = 0,
+  width = 320,
+  height = 8,
+  pattern = "ceiling",
+}
+
+tile{
+  layer = 2,
+  x = 0,
+  y = 232,
+  width = 320,
+  height = 8,
+  pattern = "ceiling",
+}
+
+tile{
+  layer = 2,
+  x = 312,
+  y = 8,
+  width = 8,
+  height = 224,
+  pattern = "ceiling",
+}
+
+tile{
+  layer = 2,
+  x = 0,
+  y = 8,
+  width = 8,
+  height = 224,
+  pattern = "ceiling",
+}
 

--- a/data/maps/components/filler/filler_000777_6.dat
+++ b/data/maps/components/filler/filler_000777_6.dat
@@ -11,6 +11,195 @@ properties{
 
 tile{
   layer = 1,
+  x = 24,
+  y = 24,
+  width = 272,
+  height = 192,
+  pattern = "placeholder.floor.high",
+}
+
+tile{
+  layer = 1,
+  x = 8,
+  y = 8,
+  width = 24,
+  height = 24,
+  pattern = "high_wall_inner_corner.nw",
+}
+
+tile{
+  layer = 1,
+  x = 288,
+  y = 8,
+  width = 24,
+  height = 24,
+  pattern = "high_wall_inner_corner.ne",
+}
+
+tile{
+  layer = 1,
+  x = 8,
+  y = 208,
+  width = 24,
+  height = 24,
+  pattern = "high_wall_inner_corner.sw",
+}
+
+tile{
+  layer = 1,
+  x = 288,
+  y = 208,
+  width = 24,
+  height = 24,
+  pattern = "high_wall_inner_corner.se",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 8,
+  width = 96,
+  height = 24,
+  pattern = "high_wall.n",
+}
+
+tile{
+  layer = 1,
+  x = 192,
+  y = 8,
+  width = 96,
+  height = 24,
+  pattern = "high_wall.n",
+}
+
+tile{
+  layer = 1,
+  x = 8,
+  y = 144,
+  width = 24,
+  height = 64,
+  pattern = "high_wall.w",
+}
+
+tile{
+  layer = 1,
+  x = 8,
+  y = 32,
+  width = 24,
+  height = 64,
+  pattern = "high_wall.w",
+}
+
+tile{
+  layer = 1,
+  x = 288,
+  y = 32,
+  width = 24,
+  height = 64,
+  pattern = "high_wall.e",
+}
+
+tile{
+  layer = 1,
+  x = 288,
+  y = 144,
+  width = 24,
+  height = 64,
+  pattern = "high_wall.e",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 208,
+  width = 96,
+  height = 24,
+  pattern = "high_wall.s",
+}
+
+tile{
+  layer = 1,
+  x = 192,
+  y = 208,
+  width = 96,
+  height = 24,
+  pattern = "high_wall.s",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 32,
+  width = 256,
+  height = 8,
+  pattern = "wall_border.high.n",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 200,
+  width = 256,
+  height = 8,
+  pattern = "wall_border.high.s",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 32,
+  width = 8,
+  height = 176,
+  pattern = "wall_border.high.w",
+}
+
+tile{
+  layer = 1,
+  x = 280,
+  y = 32,
+  width = 8,
+  height = 176,
+  pattern = "wall_border.high.e",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 32,
+  width = 8,
+  height = 8,
+  pattern = "wall_border_inner_corner.high.nw",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 200,
+  width = 8,
+  height = 8,
+  pattern = "wall_border_inner_corner.high.sw",
+}
+
+tile{
+  layer = 1,
+  x = 280,
+  y = 200,
+  width = 8,
+  height = 8,
+  pattern = "wall_border_inner_corner.high.se",
+}
+
+tile{
+  layer = 1,
+  x = 280,
+  y = 32,
+  width = 8,
+  height = 8,
+  pattern = "wall_border_inner_corner.high.ne",
+}
+
+tile{
+  layer = 1,
   x = 96,
   y = 168,
   width = 8,
@@ -181,58 +370,93 @@ tile{
 }
 
 dynamic_tile{
+  name = "enemy_1",
   layer = 1,
   x = 48,
   y = 168,
+  pattern = "placeholder.enemy",
   width = 32,
   height = 32,
-  name = "enemy_1",
-  pattern = "placeholder.enemy",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "enemy_2",
   layer = 1,
   x = 96,
   y = 88,
+  pattern = "placeholder.enemy",
   width = 32,
   height = 32,
-  name = "enemy_2",
-  pattern = "placeholder.enemy",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "enemy_3",
   layer = 1,
   x = 208,
   y = 80,
+  pattern = "placeholder.enemy",
   width = 32,
   height = 32,
-  name = "enemy_3",
-  pattern = "placeholder.enemy",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "enemy_4",
   layer = 1,
   x = 248,
   y = 176,
+  pattern = "placeholder.enemy",
   width = 32,
   height = 32,
-  name = "enemy_4",
-  pattern = "placeholder.enemy",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "enemy_5",
   layer = 1,
   x = 144,
   y = 128,
+  pattern = "placeholder.enemy",
   width = 32,
   height = 32,
-  name = "enemy_5",
-  pattern = "placeholder.enemy",
   enabled_at_start = true,
 }
 
+tile{
+  layer = 2,
+  x = 0,
+  y = 0,
+  width = 320,
+  height = 8,
+  pattern = "ceiling",
+}
+
+tile{
+  layer = 2,
+  x = 0,
+  y = 232,
+  width = 320,
+  height = 8,
+  pattern = "ceiling",
+}
+
+tile{
+  layer = 2,
+  x = 312,
+  y = 8,
+  width = 8,
+  height = 224,
+  pattern = "ceiling",
+}
+
+tile{
+  layer = 2,
+  x = 0,
+  y = 8,
+  width = 8,
+  height = 224,
+  pattern = "ceiling",
+}
 

--- a/data/maps/components/filler/filler_000777_7.dat
+++ b/data/maps/components/filler/filler_000777_7.dat
@@ -10,12 +10,48 @@ properties{
 }
 
 tile{
-  layer = 1,
+  layer = 0,
   x = 32,
   y = 32,
-  width = 104,
-  height = 72,
+  width = 264,
+  height = 184,
   pattern = "hole",
+}
+
+tile{
+  layer = 1,
+  x = 8,
+  y = 32,
+  width = 24,
+  height = 64,
+  pattern = "high_wall.w",
+}
+
+tile{
+  layer = 1,
+  x = 8,
+  y = 144,
+  width = 24,
+  height = 64,
+  pattern = "high_wall.w",
+}
+
+tile{
+  layer = 1,
+  x = 288,
+  y = 32,
+  width = 24,
+  height = 64,
+  pattern = "high_wall.e",
+}
+
+tile{
+  layer = 1,
+  x = 288,
+  y = 144,
+  width = 24,
+  height = 64,
+  pattern = "high_wall.e",
 }
 
 tile{
@@ -49,15 +85,6 @@ tile{
   layer = 1,
   x = 184,
   y = 32,
-  width = 104,
-  height = 72,
-  pattern = "hole",
-}
-
-tile{
-  layer = 1,
-  x = 184,
-  y = 32,
   width = 88,
   height = 16,
   pattern = "chasm_wall.n",
@@ -79,15 +106,6 @@ tile{
   width = 16,
   height = 56,
   pattern = "chasm_wall.e",
-}
-
-tile{
-  layer = 1,
-  x = 32,
-  y = 136,
-  width = 104,
-  height = 72,
-  pattern = "hole",
 }
 
 tile{
@@ -115,15 +133,6 @@ tile{
   width = 16,
   height = 16,
   pattern = "chasm_wall_inner_corner.sw",
-}
-
-tile{
-  layer = 1,
-  x = 184,
-  y = 136,
-  width = 104,
-  height = 72,
-  pattern = "hole",
 }
 
 tile{
@@ -333,37 +342,198 @@ tile{
   pattern = "hole_border_inner_corner.se",
 }
 
+tile{
+  layer = 1,
+  x = 24,
+  y = 104,
+  width = 272,
+  height = 32,
+  pattern = "placeholder.floor.high",
+}
+
+tile{
+  layer = 1,
+  x = 136,
+  y = 24,
+  width = 48,
+  height = 192,
+  pattern = "placeholder.floor.high",
+}
+
+tile{
+  layer = 1,
+  x = 136,
+  y = 32,
+  width = 48,
+  height = 8,
+  pattern = "wall_border.high.n",
+}
+
+tile{
+  layer = 1,
+  x = 136,
+  y = 200,
+  width = 48,
+  height = 8,
+  pattern = "wall_border.high.s",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 104,
+  width = 8,
+  height = 32,
+  pattern = "wall_border.high.w",
+}
+
+tile{
+  layer = 1,
+  x = 280,
+  y = 104,
+  width = 8,
+  height = 32,
+  pattern = "wall_border.high.e",
+}
+
+tile{
+  layer = 1,
+  x = 8,
+  y = 8,
+  width = 24,
+  height = 24,
+  pattern = "high_wall_inner_corner.nw",
+}
+
+tile{
+  layer = 1,
+  x = 288,
+  y = 8,
+  width = 24,
+  height = 24,
+  pattern = "high_wall_inner_corner.ne",
+}
+
+tile{
+  layer = 1,
+  x = 288,
+  y = 208,
+  width = 24,
+  height = 24,
+  pattern = "high_wall_inner_corner.se",
+}
+
+tile{
+  layer = 1,
+  x = 8,
+  y = 208,
+  width = 24,
+  height = 24,
+  pattern = "high_wall_inner_corner.sw",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 8,
+  width = 96,
+  height = 24,
+  pattern = "high_wall.n",
+}
+
+tile{
+  layer = 1,
+  x = 192,
+  y = 8,
+  width = 96,
+  height = 24,
+  pattern = "high_wall.n",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 208,
+  width = 96,
+  height = 24,
+  pattern = "high_wall.s",
+}
+
+tile{
+  layer = 1,
+  x = 192,
+  y = 208,
+  width = 96,
+  height = 24,
+  pattern = "high_wall.s",
+}
+
 dynamic_tile{
+  name = "enemy_3",
   layer = 1,
   x = 72,
   y = 104,
+  pattern = "placeholder.enemy",
   width = 32,
   height = 32,
-  name = "enemy_3",
-  pattern = "placeholder.enemy",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "enemy_2",
   layer = 1,
   x = 216,
   y = 104,
+  pattern = "placeholder.enemy",
   width = 32,
   height = 32,
-  name = "enemy_2",
-  pattern = "placeholder.enemy",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "enemy_4",
   layer = 1,
   x = 144,
   y = 144,
+  pattern = "placeholder.enemy",
   width = 32,
   height = 32,
-  name = "enemy_4",
-  pattern = "placeholder.enemy",
   enabled_at_start = true,
 }
 
+tile{
+  layer = 2,
+  x = 0,
+  y = 0,
+  width = 320,
+  height = 8,
+  pattern = "ceiling",
+}
+
+tile{
+  layer = 2,
+  x = 0,
+  y = 232,
+  width = 320,
+  height = 8,
+  pattern = "ceiling",
+}
+
+tile{
+  layer = 2,
+  x = 312,
+  y = 8,
+  width = 8,
+  height = 224,
+  pattern = "ceiling",
+}
+
+tile{
+  layer = 2,
+  x = 0,
+  y = 8,
+  width = 8,
+  height = 224,
+  pattern = "ceiling",
+}
 

--- a/data/maps/components/filler/filler_000777_8.dat
+++ b/data/maps/components/filler/filler_000777_8.dat
@@ -11,6 +11,51 @@ properties{
 
 tile{
   layer = 1,
+  x = 24,
+  y = 24,
+  width = 272,
+  height = 192,
+  pattern = "placeholder.floor.high",
+}
+
+tile{
+  layer = 1,
+  x = 128,
+  y = 200,
+  width = 64,
+  height = 8,
+  pattern = "wall_border.high.s",
+}
+
+tile{
+  layer = 1,
+  x = 128,
+  y = 32,
+  width = 64,
+  height = 8,
+  pattern = "wall_border.high.n",
+}
+
+tile{
+  layer = 1,
+  x = 280,
+  y = 96,
+  width = 8,
+  height = 48,
+  pattern = "wall_border.high.e",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 96,
+  width = 8,
+  height = 48,
+  pattern = "wall_border.high.w",
+}
+
+tile{
+  layer = 1,
   x = 216,
   y = 88,
   width = 16,
@@ -550,36 +595,71 @@ tile{
 }
 
 dynamic_tile{
+  name = "enemy_1",
   layer = 1,
   x = 96,
   y = 104,
+  pattern = "placeholder.enemy",
   width = 32,
   height = 32,
-  name = "enemy_1",
-  pattern = "placeholder.enemy",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "enemy_2",
   layer = 1,
   x = 192,
   y = 104,
+  pattern = "placeholder.enemy",
   width = 32,
   height = 32,
-  name = "enemy_2",
-  pattern = "placeholder.enemy",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "enemy_3",
   layer = 1,
   x = 144,
   y = 104,
+  pattern = "placeholder.enemy",
   width = 32,
   height = 32,
-  name = "enemy_3",
-  pattern = "placeholder.enemy",
   enabled_at_start = true,
 }
 
+tile{
+  layer = 2,
+  x = 0,
+  y = 0,
+  width = 320,
+  height = 8,
+  pattern = "ceiling",
+}
+
+tile{
+  layer = 2,
+  x = 0,
+  y = 232,
+  width = 320,
+  height = 8,
+  pattern = "ceiling",
+}
+
+tile{
+  layer = 2,
+  x = 312,
+  y = 8,
+  width = 8,
+  height = 224,
+  pattern = "ceiling",
+}
+
+tile{
+  layer = 2,
+  x = 0,
+  y = 8,
+  width = 8,
+  height = 224,
+  pattern = "ceiling",
+}
 

--- a/data/maps/components/filler/filler_000777_9.dat
+++ b/data/maps/components/filler/filler_000777_9.dat
@@ -11,6 +11,15 @@ properties{
 
 tile{
   layer = 1,
+  x = 24,
+  y = 24,
+  width = 272,
+  height = 192,
+  pattern = "placeholder.floor.high",
+}
+
+tile{
+  layer = 1,
   x = 56,
   y = 56,
   width = 16,
@@ -135,6 +144,186 @@ tile{
   pattern = "placeholder.barrier.3",
 }
 
+tile{
+  layer = 1,
+  x = 8,
+  y = 8,
+  width = 24,
+  height = 24,
+  pattern = "high_wall_inner_corner.nw",
+}
+
+tile{
+  layer = 1,
+  x = 288,
+  y = 8,
+  width = 24,
+  height = 24,
+  pattern = "high_wall_inner_corner.ne",
+}
+
+tile{
+  layer = 1,
+  x = 8,
+  y = 208,
+  width = 24,
+  height = 24,
+  pattern = "high_wall_inner_corner.sw",
+}
+
+tile{
+  layer = 1,
+  x = 288,
+  y = 208,
+  width = 24,
+  height = 24,
+  pattern = "high_wall_inner_corner.se",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 8,
+  width = 96,
+  height = 24,
+  pattern = "high_wall.n",
+}
+
+tile{
+  layer = 1,
+  x = 192,
+  y = 8,
+  width = 96,
+  height = 24,
+  pattern = "high_wall.n",
+}
+
+tile{
+  layer = 1,
+  x = 8,
+  y = 144,
+  width = 24,
+  height = 64,
+  pattern = "high_wall.w",
+}
+
+tile{
+  layer = 1,
+  x = 8,
+  y = 32,
+  width = 24,
+  height = 64,
+  pattern = "high_wall.w",
+}
+
+tile{
+  layer = 1,
+  x = 288,
+  y = 32,
+  width = 24,
+  height = 64,
+  pattern = "high_wall.e",
+}
+
+tile{
+  layer = 1,
+  x = 288,
+  y = 144,
+  width = 24,
+  height = 64,
+  pattern = "high_wall.e",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 208,
+  width = 96,
+  height = 24,
+  pattern = "high_wall.s",
+}
+
+tile{
+  layer = 1,
+  x = 192,
+  y = 208,
+  width = 96,
+  height = 24,
+  pattern = "high_wall.s",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 32,
+  width = 256,
+  height = 8,
+  pattern = "wall_border.high.n",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 200,
+  width = 256,
+  height = 8,
+  pattern = "wall_border.high.s",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 32,
+  width = 8,
+  height = 176,
+  pattern = "wall_border.high.w",
+}
+
+tile{
+  layer = 1,
+  x = 280,
+  y = 32,
+  width = 8,
+  height = 176,
+  pattern = "wall_border.high.e",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 32,
+  width = 8,
+  height = 8,
+  pattern = "wall_border_inner_corner.high.nw",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 200,
+  width = 8,
+  height = 8,
+  pattern = "wall_border_inner_corner.high.sw",
+}
+
+tile{
+  layer = 1,
+  x = 280,
+  y = 200,
+  width = 8,
+  height = 8,
+  pattern = "wall_border_inner_corner.high.se",
+}
+
+tile{
+  layer = 1,
+  x = 280,
+  y = 32,
+  width = 8,
+  height = 8,
+  pattern = "wall_border_inner_corner.high.ne",
+}
+
 dynamic_tile{
   name = "pot_1",
   layer = 1,
@@ -212,4 +401,39 @@ dynamic_tile{
   enabled_at_start = true,
 }
 
+tile{
+  layer = 2,
+  x = 0,
+  y = 0,
+  width = 320,
+  height = 8,
+  pattern = "ceiling",
+}
+
+tile{
+  layer = 2,
+  x = 0,
+  y = 232,
+  width = 320,
+  height = 8,
+  pattern = "ceiling",
+}
+
+tile{
+  layer = 2,
+  x = 312,
+  y = 8,
+  width = 8,
+  height = 224,
+  pattern = "ceiling",
+}
+
+tile{
+  layer = 2,
+  x = 0,
+  y = 8,
+  width = 8,
+  height = 224,
+  pattern = "ceiling",
+}
 

--- a/data/maps/components/filler/filler_002000_wall_south.dat
+++ b/data/maps/components/filler/filler_002000_wall_south.dat
@@ -1,0 +1,19 @@
+properties{
+  x = 0,
+  y = 0,
+  width = 320,
+  height = 240,
+  min_layer = 0,
+  max_layer = 2,
+  tileset = "dungeon.tower_of_hera",
+}
+
+tile{
+  layer = 1,
+  x = 144,
+  y = 208,
+  width = 32,
+  height = 24,
+  pattern = "high_wall.s",
+}
+

--- a/data/maps/components/filler/filler_002007_1.dat
+++ b/data/maps/components/filler/filler_002007_1.dat
@@ -11,6 +11,15 @@ properties{
 
 tile{
   layer = 1,
+  x = 24,
+  y = 136,
+  width = 272,
+  height = 16,
+  pattern = "placeholder.floor.high",
+}
+
+tile{
+  layer = 1,
   x = 8,
   y = 144,
   width = 24,
@@ -72,4 +81,21 @@ tile{
   pattern = "ceiling",
 }
 
+tile{
+  layer = 2,
+  x = 0,
+  y = 136,
+  width = 8,
+  height = 32,
+  pattern = "ceiling",
+}
+
+tile{
+  layer = 2,
+  x = 312,
+  y = 136,
+  width = 8,
+  height = 32,
+  pattern = "ceiling",
+}
 

--- a/data/maps/components/filler/filler_002007_2.dat
+++ b/data/maps/components/filler/filler_002007_2.dat
@@ -10,25 +10,7 @@ properties{
 }
 
 tile{
-  layer = 1,
-  x = 32,
-  y = 200,
-  width = 8,
-  height = 8,
-  pattern = "wall_border_inner_corner.high.sw",
-}
-
-tile{
-  layer = 1,
-  x = 280,
-  y = 200,
-  width = 8,
-  height = 8,
-  pattern = "wall_border_inner_corner.high.se",
-}
-
-tile{
-  layer = 1,
+  layer = 0,
   x = 32,
   y = 136,
   width = 256,
@@ -37,7 +19,7 @@ tile{
 }
 
 tile{
-  layer = 1,
+  layer = 0,
   x = 32,
   y = 192,
   width = 16,
@@ -46,7 +28,7 @@ tile{
 }
 
 tile{
-  layer = 1,
+  layer = 0,
   x = 272,
   y = 192,
   width = 16,
@@ -55,7 +37,7 @@ tile{
 }
 
 tile{
-  layer = 1,
+  layer = 0,
   x = 48,
   y = 192,
   width = 32,
@@ -64,7 +46,7 @@ tile{
 }
 
 tile{
-  layer = 1,
+  layer = 0,
   x = 96,
   y = 176,
   width = 16,
@@ -73,7 +55,7 @@ tile{
 }
 
 tile{
-  layer = 1,
+  layer = 0,
   x = 80,
   y = 192,
   width = 16,
@@ -82,7 +64,7 @@ tile{
 }
 
 tile{
-  layer = 1,
+  layer = 0,
   x = 80,
   y = 176,
   width = 16,
@@ -91,7 +73,7 @@ tile{
 }
 
 tile{
-  layer = 1,
+  layer = 0,
   x = 112,
   y = 176,
   width = 16,
@@ -100,7 +82,7 @@ tile{
 }
 
 tile{
-  layer = 1,
+  layer = 0,
   x = 112,
   y = 192,
   width = 16,
@@ -109,7 +91,7 @@ tile{
 }
 
 tile{
-  layer = 1,
+  layer = 0,
   x = 208,
   y = 176,
   width = 16,
@@ -118,7 +100,7 @@ tile{
 }
 
 tile{
-  layer = 1,
+  layer = 0,
   x = 192,
   y = 192,
   width = 16,
@@ -127,7 +109,7 @@ tile{
 }
 
 tile{
-  layer = 1,
+  layer = 0,
   x = 192,
   y = 176,
   width = 16,
@@ -136,7 +118,7 @@ tile{
 }
 
 tile{
-  layer = 1,
+  layer = 0,
   x = 224,
   y = 176,
   width = 16,
@@ -145,7 +127,7 @@ tile{
 }
 
 tile{
-  layer = 1,
+  layer = 0,
   x = 224,
   y = 192,
   width = 16,
@@ -154,7 +136,7 @@ tile{
 }
 
 tile{
-  layer = 1,
+  layer = 0,
   x = 240,
   y = 192,
   width = 32,
@@ -163,12 +145,30 @@ tile{
 }
 
 tile{
-  layer = 1,
+  layer = 0,
   x = 128,
   y = 192,
   width = 64,
   height = 16,
   pattern = "chasm_wall.s",
+}
+
+tile{
+  layer = 0,
+  x = 272,
+  y = 136,
+  width = 16,
+  height = 56,
+  pattern = "chasm_wall.e",
+}
+
+tile{
+  layer = 0,
+  x = 32,
+  y = 136,
+  width = 16,
+  height = 56,
+  pattern = "chasm_wall.w",
 }
 
 tile{
@@ -187,24 +187,6 @@ tile{
   width = 16,
   height = 16,
   pattern = "small_statue.1",
-}
-
-tile{
-  layer = 1,
-  x = 272,
-  y = 136,
-  width = 16,
-  height = 56,
-  pattern = "chasm_wall.e",
-}
-
-tile{
-  layer = 1,
-  x = 32,
-  y = 136,
-  width = 16,
-  height = 56,
-  pattern = "chasm_wall.w",
 }
 
 tile{
@@ -216,4 +198,75 @@ tile{
   pattern = "hole_border.n",
 }
 
+tile{
+  layer = 1,
+  x = 8,
+  y = 208,
+  width = 24,
+  height = 24,
+  pattern = "high_wall_inner_corner.sw",
+}
+
+tile{
+  layer = 1,
+  x = 288,
+  y = 208,
+  width = 24,
+  height = 24,
+  pattern = "high_wall_inner_corner.se",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 208,
+  width = 256,
+  height = 24,
+  pattern = "high_wall.s",
+}
+
+tile{
+  layer = 1,
+  x = 8,
+  y = 144,
+  width = 24,
+  height = 64,
+  pattern = "high_wall.w",
+}
+
+tile{
+  layer = 1,
+  x = 288,
+  y = 144,
+  width = 24,
+  height = 64,
+  pattern = "high_wall.e",
+}
+
+tile{
+  layer = 2,
+  x = 0,
+  y = 136,
+  width = 8,
+  height = 96,
+  pattern = "ceiling",
+}
+
+tile{
+  layer = 2,
+  x = 0,
+  y = 232,
+  width = 320,
+  height = 8,
+  pattern = "ceiling",
+}
+
+tile{
+  layer = 2,
+  x = 312,
+  y = 136,
+  width = 8,
+  height = 96,
+  pattern = "ceiling",
+}
 

--- a/data/maps/components/filler/filler_002007_4.dat
+++ b/data/maps/components/filler/filler_002007_4.dat
@@ -11,6 +11,51 @@ properties{
 
 tile{
   layer = 1,
+  x = 24,
+  y = 136,
+  width = 272,
+  height = 80,
+  pattern = "placeholder.floor.high",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 144,
+  width = 8,
+  height = 16,
+  pattern = "wall_border.high.w",
+}
+
+tile{
+  layer = 1,
+  x = 280,
+  y = 144,
+  width = 8,
+  height = 16,
+  pattern = "wall_border.high.e",
+}
+
+tile{
+  layer = 1,
+  x = 96,
+  y = 200,
+  width = 128,
+  height = 8,
+  pattern = "wall_border.high.s",
+}
+
+tile{
+  layer = 1,
+  x = 96,
+  y = 208,
+  width = 128,
+  height = 24,
+  pattern = "high_wall.s",
+}
+
+tile{
+  layer = 1,
   x = 8,
   y = 160,
   width = 24,
@@ -217,6 +262,24 @@ tile{
 }
 
 tile{
+  layer = 1,
+  x = 8,
+  y = 144,
+  width = 24,
+  height = 16,
+  pattern = "high_wall.w",
+}
+
+tile{
+  layer = 1,
+  x = 288,
+  y = 144,
+  width = 24,
+  height = 16,
+  pattern = "high_wall.e",
+}
+
+tile{
   layer = 2,
   x = 8,
   y = 184,
@@ -234,4 +297,30 @@ tile{
   pattern = "ceiling",
 }
 
+tile{
+  layer = 2,
+  x = 0,
+  y = 136,
+  width = 8,
+  height = 96,
+  pattern = "ceiling",
+}
+
+tile{
+  layer = 2,
+  x = 0,
+  y = 232,
+  width = 320,
+  height = 8,
+  pattern = "ceiling",
+}
+
+tile{
+  layer = 2,
+  x = 312,
+  y = 136,
+  width = 8,
+  height = 96,
+  pattern = "ceiling",
+}
 

--- a/data/maps/components/filler/filler_010000_wall_east.dat
+++ b/data/maps/components/filler/filler_010000_wall_east.dat
@@ -1,0 +1,19 @@
+properties{
+  x = 0,
+  y = 0,
+  width = 320,
+  height = 240,
+  min_layer = 0,
+  max_layer = 2,
+  tileset = "dungeon.tower_of_hera",
+}
+
+tile{
+  layer = 1,
+  x = 288,
+  y = 112,
+  width = 24,
+  height = 16,
+  pattern = "high_wall.e",
+}
+

--- a/data/maps/components/filler/filler_040000_wall_west.dat
+++ b/data/maps/components/filler/filler_040000_wall_west.dat
@@ -1,0 +1,19 @@
+properties{
+  x = 0,
+  y = 0,
+  width = 320,
+  height = 240,
+  min_layer = 0,
+  max_layer = 2,
+  tileset = "dungeon.tower_of_hera",
+}
+
+tile{
+  layer = 1,
+  x = 8,
+  y = 112,
+  width = 24,
+  height = 16,
+  pattern = "high_wall.w",
+}
+

--- a/data/maps/components/filler/filler_200000_wall_north.dat
+++ b/data/maps/components/filler/filler_200000_wall_north.dat
@@ -1,0 +1,19 @@
+properties{
+  x = 0,
+  y = 0,
+  width = 320,
+  height = 240,
+  min_layer = 0,
+  max_layer = 2,
+  tileset = "dungeon.tower_of_hera",
+}
+
+tile{
+  layer = 1,
+  x = 144,
+  y = 8,
+  width = 32,
+  height = 24,
+  pattern = "high_wall.n",
+}
+

--- a/data/maps/components/filler/filler_200700_1.dat
+++ b/data/maps/components/filler/filler_200700_1.dat
@@ -11,6 +11,15 @@ properties{
 
 tile{
   layer = 1,
+  x = 24,
+  y = 88,
+  width = 272,
+  height = 16,
+  pattern = "placeholder.floor.high",
+}
+
+tile{
+  layer = 1,
   x = 8,
   y = 72,
   width = 24,
@@ -72,4 +81,21 @@ tile{
   pattern = "ceiling",
 }
 
+tile{
+  layer = 2,
+  x = 0,
+  y = 72,
+  width = 8,
+  height = 32,
+  pattern = "ceiling",
+}
+
+tile{
+  layer = 2,
+  x = 312,
+  y = 72,
+  width = 8,
+  height = 32,
+  pattern = "ceiling",
+}
 

--- a/data/maps/components/filler/filler_202777_1.dat
+++ b/data/maps/components/filler/filler_202777_1.dat
@@ -11,6 +11,78 @@ properties{
 
 tile{
   layer = 1,
+  x = 24,
+  y = 104,
+  width = 32,
+  height = 32,
+  pattern = "placeholder.floor.high",
+}
+
+tile{
+  layer = 1,
+  x = 264,
+  y = 104,
+  width = 32,
+  height = 32,
+  pattern = "placeholder.floor.high",
+}
+
+tile{
+  layer = 1,
+  x = 280,
+  y = 96,
+  width = 8,
+  height = 48,
+  pattern = "wall_border.high.e",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 96,
+  width = 8,
+  height = 48,
+  pattern = "wall_border.high.w",
+}
+
+tile{
+  layer = 1,
+  x = 8,
+  y = 0,
+  width = 24,
+  height = 96,
+  pattern = "high_wall.w",
+}
+
+tile{
+  layer = 1,
+  x = 8,
+  y = 144,
+  width = 24,
+  height = 96,
+  pattern = "high_wall.w",
+}
+
+tile{
+  layer = 1,
+  x = 288,
+  y = 0,
+  width = 24,
+  height = 96,
+  pattern = "high_wall.e",
+}
+
+tile{
+  layer = 1,
+  x = 288,
+  y = 144,
+  width = 24,
+  height = 96,
+  pattern = "high_wall.e",
+}
+
+tile{
+  layer = 1,
   x = 32,
   y = 16,
   width = 256,
@@ -351,61 +423,25 @@ tile{
   pattern = "wall_torch.e",
 }
 
-tile{
-  layer = 1,
-  x = 8,
-  y = 16,
-  width = 24,
-  height = 16,
-  pattern = "high_wall.w",
-}
-
-tile{
-  layer = 1,
-  x = 8,
-  y = 208,
-  width = 24,
-  height = 16,
-  pattern = "high_wall.w",
-}
-
-tile{
-  layer = 1,
-  x = 288,
-  y = 16,
-  width = 24,
-  height = 16,
-  pattern = "high_wall.e",
-}
-
-tile{
-  layer = 1,
-  x = 288,
-  y = 208,
-  width = 24,
-  height = 16,
-  pattern = "high_wall.e",
-}
-
 dynamic_tile{
+  name = "enemy_3",
   layer = 1,
   x = 88,
   y = 104,
+  pattern = "placeholder.enemy",
   width = 32,
   height = 32,
-  name = "enemy_3",
-  pattern = "placeholder.enemy",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "enemy_2",
   layer = 1,
   x = 200,
   y = 104,
+  pattern = "placeholder.enemy",
   width = 32,
   height = 32,
-  name = "enemy_2",
-  pattern = "placeholder.enemy",
   enabled_at_start = true,
 }
 
@@ -465,38 +501,19 @@ tile{
 
 tile{
   layer = 2,
-  x = 8,
-  y = 224,
-  width = 24,
-  height = 16,
-  pattern = "high_wall.w",
-}
-
-tile{
-  layer = 2,
-  x = 8,
+  x = 0,
   y = 0,
-  width = 24,
-  height = 16,
-  pattern = "high_wall.w",
+  width = 8,
+  height = 240,
+  pattern = "ceiling",
 }
 
 tile{
   layer = 2,
-  x = 288,
-  y = 224,
-  width = 24,
-  height = 16,
-  pattern = "high_wall.e",
-}
-
-tile{
-  layer = 2,
-  x = 288,
+  x = 312,
   y = 0,
-  width = 24,
-  height = 16,
-  pattern = "high_wall.e",
+  width = 8,
+  height = 240,
+  pattern = "ceiling",
 }
-
 

--- a/data/maps/components/filler/filler_202777_2.dat
+++ b/data/maps/components/filler/filler_202777_2.dat
@@ -11,6 +11,33 @@ properties{
 
 tile{
   layer = 1,
+  x = 24,
+  y = 88,
+  width = 272,
+  height = 64,
+  pattern = "placeholder.floor.high",
+}
+
+tile{
+  layer = 1,
+  x = 280,
+  y = 96,
+  width = 8,
+  height = 48,
+  pattern = "wall_border.high.e",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 96,
+  width = 8,
+  height = 48,
+  pattern = "wall_border.high.w",
+}
+
+tile{
+  layer = 1,
   x = 40,
   y = 136,
   width = 240,
@@ -298,22 +325,22 @@ tile{
 }
 
 dynamic_tile{
+  name = "enemy_3",
   layer = 1,
   x = 144,
   y = 104,
+  pattern = "placeholder.enemy",
   width = 32,
   height = 32,
-  name = "enemy_3",
-  pattern = "placeholder.enemy",
   enabled_at_start = true,
 }
 
 tile{
   layer = 2,
   x = 8,
-  y = 8,
+  y = 0,
   width = 304,
-  height = 64,
+  height = 72,
   pattern = "ceiling",
 }
 
@@ -322,8 +349,25 @@ tile{
   x = 8,
   y = 168,
   width = 304,
-  height = 64,
+  height = 72,
   pattern = "ceiling",
 }
 
+tile{
+  layer = 2,
+  x = 0,
+  y = 0,
+  width = 8,
+  height = 240,
+  pattern = "ceiling",
+}
+
+tile{
+  layer = 2,
+  x = 312,
+  y = 0,
+  width = 8,
+  height = 240,
+  pattern = "ceiling",
+}
 

--- a/data/maps/components/filler/filler_202777_4.dat
+++ b/data/maps/components/filler/filler_202777_4.dat
@@ -11,6 +11,51 @@ properties{
 
 tile{
   layer = 1,
+  x = 24,
+  y = 24,
+  width = 272,
+  height = 192,
+  pattern = "placeholder.floor.high",
+}
+
+tile{
+  layer = 1,
+  x = 280,
+  y = 32,
+  width = 8,
+  height = 176,
+  pattern = "wall_border.high.e",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 32,
+  width = 8,
+  height = 176,
+  pattern = "wall_border.high.w",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 200,
+  width = 256,
+  height = 8,
+  pattern = "wall_border.high.s",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 32,
+  width = 256,
+  height = 8,
+  pattern = "wall_border.high.n",
+}
+
+tile{
+  layer = 1,
   x = 56,
   y = 32,
   width = 16,
@@ -261,6 +306,132 @@ tile{
   pattern = "placeholder.big_barrier.3",
 }
 
+tile{
+  layer = 1,
+  x = 8,
+  y = 8,
+  width = 24,
+  height = 24,
+  pattern = "high_wall_inner_corner.nw",
+}
+
+tile{
+  layer = 1,
+  x = 288,
+  y = 8,
+  width = 24,
+  height = 24,
+  pattern = "high_wall_inner_corner.ne",
+}
+
+tile{
+  layer = 1,
+  x = 288,
+  y = 208,
+  width = 24,
+  height = 24,
+  pattern = "high_wall_inner_corner.se",
+}
+
+tile{
+  layer = 1,
+  x = 8,
+  y = 208,
+  width = 24,
+  height = 24,
+  pattern = "high_wall_inner_corner.sw",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 8,
+  width = 256,
+  height = 24,
+  pattern = "high_wall.n",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 208,
+  width = 256,
+  height = 24,
+  pattern = "high_wall.s",
+}
+
+tile{
+  layer = 1,
+  x = 288,
+  y = 144,
+  width = 24,
+  height = 64,
+  pattern = "high_wall.e",
+}
+
+tile{
+  layer = 1,
+  x = 288,
+  y = 32,
+  width = 24,
+  height = 64,
+  pattern = "high_wall.e",
+}
+
+tile{
+  layer = 1,
+  x = 8,
+  y = 144,
+  width = 24,
+  height = 64,
+  pattern = "high_wall.w",
+}
+
+tile{
+  layer = 1,
+  x = 8,
+  y = 32,
+  width = 24,
+  height = 64,
+  pattern = "high_wall.w",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 32,
+  width = 8,
+  height = 8,
+  pattern = "wall_border_inner_corner.high.nw",
+}
+
+tile{
+  layer = 1,
+  x = 280,
+  y = 32,
+  width = 8,
+  height = 8,
+  pattern = "wall_border_inner_corner.high.ne",
+}
+
+tile{
+  layer = 1,
+  x = 280,
+  y = 200,
+  width = 8,
+  height = 8,
+  pattern = "wall_border_inner_corner.high.se",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 200,
+  width = 8,
+  height = 8,
+  pattern = "wall_border_inner_corner.high.sw",
+}
+
 enemy{
   layer = 1,
   x = 88,
@@ -294,47 +465,82 @@ enemy{
 }
 
 dynamic_tile{
-  layer = 1,
-  x = 40,
-  y = 184,
-  width = 16,
-  height = 16,
   name = "pot_1",
+  layer = 1,
+  x = 40,
+  y = 184,
   pattern = "placeholder.pot",
+  width = 16,
+  height = 16,
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "pot_2",
   layer = 1,
   x = 40,
   y = 40,
+  pattern = "placeholder.pot",
   width = 16,
   height = 16,
-  name = "pot_2",
-  pattern = "placeholder.pot",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "pot_3",
   layer = 1,
   x = 264,
   y = 184,
+  pattern = "placeholder.pot",
   width = 16,
   height = 16,
-  name = "pot_3",
-  pattern = "placeholder.pot",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "pot_4",
   layer = 1,
   x = 264,
   y = 40,
+  pattern = "placeholder.pot",
   width = 16,
   height = 16,
-  name = "pot_4",
-  pattern = "placeholder.pot",
   enabled_at_start = true,
 }
 
+tile{
+  layer = 2,
+  x = 0,
+  y = 0,
+  width = 320,
+  height = 8,
+  pattern = "ceiling",
+}
+
+tile{
+  layer = 2,
+  x = 0,
+  y = 232,
+  width = 320,
+  height = 8,
+  pattern = "ceiling",
+}
+
+tile{
+  layer = 2,
+  x = 312,
+  y = 8,
+  width = 8,
+  height = 224,
+  pattern = "ceiling",
+}
+
+tile{
+  layer = 2,
+  x = 0,
+  y = 8,
+  width = 8,
+  height = 224,
+  pattern = "ceiling",
+}
 

--- a/data/maps/components/obstacle_bow/obstacle_bow_nsew_000700_1.dat
+++ b/data/maps/components/obstacle_bow/obstacle_bow_nsew_000700_1.dat
@@ -11,6 +11,24 @@ properties{
 
 tile{
   layer = 1,
+  x = 24,
+  y = 24,
+  width = 272,
+  height = 80,
+  pattern = "placeholder.floor.high",
+}
+
+tile{
+  layer = 1,
+  x = 80,
+  y = 32,
+  width = 160,
+  height = 8,
+  pattern = "wall_border.high.n",
+}
+
+tile{
+  layer = 1,
   x = 8,
   y = 72,
   width = 24,
@@ -189,6 +207,15 @@ tile{
   pattern = "wall_border_outer_corner.high.nw",
 }
 
+tile{
+  layer = 1,
+  x = 80,
+  y = 8,
+  width = 160,
+  height = 24,
+  pattern = "high_wall.n",
+}
+
 dynamic_tile{
   name = "switch",
   layer = 1,
@@ -270,6 +297,33 @@ tile{
   y = 8,
   width = 48,
   height = 64,
+  pattern = "ceiling",
+}
+
+tile{
+  layer = 2,
+  x = 0,
+  y = 8,
+  width = 8,
+  height = 96,
+  pattern = "ceiling",
+}
+
+tile{
+  layer = 2,
+  x = 0,
+  y = 0,
+  width = 320,
+  height = 8,
+  pattern = "ceiling",
+}
+
+tile{
+  layer = 2,
+  x = 312,
+  y = 8,
+  width = 8,
+  height = 96,
   pattern = "ceiling",
 }
 

--- a/data/maps/components/obstacle_bow/obstacle_bow_nsew_000777_lampbow.dat
+++ b/data/maps/components/obstacle_bow/obstacle_bow_nsew_000777_lampbow.dat
@@ -9,6 +9,195 @@ properties{
   music = "same",
 }
 
+tile{
+  layer = 1,
+  x = 24,
+  y = 24,
+  width = 272,
+  height = 192,
+  pattern = "placeholder.floor.high",
+}
+
+tile{
+  layer = 1,
+  x = 8,
+  y = 8,
+  width = 24,
+  height = 24,
+  pattern = "high_wall_inner_corner.nw",
+}
+
+tile{
+  layer = 1,
+  x = 8,
+  y = 208,
+  width = 24,
+  height = 24,
+  pattern = "high_wall_inner_corner.sw",
+}
+
+tile{
+  layer = 1,
+  x = 288,
+  y = 208,
+  width = 24,
+  height = 24,
+  pattern = "high_wall_inner_corner.se",
+}
+
+tile{
+  layer = 1,
+  x = 288,
+  y = 8,
+  width = 24,
+  height = 24,
+  pattern = "high_wall_inner_corner.ne",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 8,
+  width = 96,
+  height = 24,
+  pattern = "high_wall.n",
+}
+
+tile{
+  layer = 1,
+  x = 192,
+  y = 208,
+  width = 96,
+  height = 24,
+  pattern = "high_wall.s",
+}
+
+tile{
+  layer = 1,
+  x = 8,
+  y = 32,
+  width = 24,
+  height = 64,
+  pattern = "high_wall.w",
+}
+
+tile{
+  layer = 1,
+  x = 288,
+  y = 32,
+  width = 24,
+  height = 64,
+  pattern = "high_wall.e",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 32,
+  width = 256,
+  height = 8,
+  pattern = "wall_border.high.n",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 208,
+  width = 96,
+  height = 24,
+  pattern = "high_wall.s",
+}
+
+tile{
+  layer = 1,
+  x = 192,
+  y = 8,
+  width = 96,
+  height = 24,
+  pattern = "high_wall.n",
+}
+
+tile{
+  layer = 1,
+  x = 288,
+  y = 144,
+  width = 24,
+  height = 64,
+  pattern = "high_wall.e",
+}
+
+tile{
+  layer = 1,
+  x = 8,
+  y = 144,
+  width = 24,
+  height = 64,
+  pattern = "high_wall.w",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 200,
+  width = 256,
+  height = 8,
+  pattern = "wall_border.high.s",
+}
+
+tile{
+  layer = 1,
+  x = 280,
+  y = 32,
+  width = 8,
+  height = 176,
+  pattern = "wall_border.high.e",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 32,
+  width = 8,
+  height = 176,
+  pattern = "wall_border.high.w",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 32,
+  width = 8,
+  height = 8,
+  pattern = "wall_border_inner_corner.high.nw",
+}
+
+tile{
+  layer = 1,
+  x = 280,
+  y = 32,
+  width = 8,
+  height = 8,
+  pattern = "wall_border_inner_corner.high.ne",
+}
+
+tile{
+  layer = 1,
+  x = 280,
+  y = 200,
+  width = 8,
+  height = 8,
+  pattern = "wall_border_inner_corner.high.se",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 200,
+  width = 8,
+  height = 8,
+  pattern = "wall_border_inner_corner.high.sw",
+}
+
 dynamic_tile{
   name = "switch",
   layer = 1,
@@ -216,5 +405,41 @@ dynamic_tile{
   width = 16,
   height = 16,
   enabled_at_start = true,
+}
+
+tile{
+  layer = 2,
+  x = 0,
+  y = 8,
+  width = 8,
+  height = 224,
+  pattern = "ceiling",
+}
+
+tile{
+  layer = 2,
+  x = 312,
+  y = 8,
+  width = 8,
+  height = 224,
+  pattern = "ceiling",
+}
+
+tile{
+  layer = 2,
+  x = 0,
+  y = 232,
+  width = 320,
+  height = 8,
+  pattern = "ceiling",
+}
+
+tile{
+  layer = 2,
+  x = 0,
+  y = 0,
+  width = 320,
+  height = 8,
+  pattern = "ceiling",
 }
 

--- a/data/maps/components/obstacle_flippers/obstacle_flippers_e_212777_1.dat
+++ b/data/maps/components/obstacle_flippers/obstacle_flippers_e_212777_1.dat
@@ -11,8 +11,170 @@ properties{
 
 tile{
   layer = 1,
+  x = 24,
+  y = 24,
+  width = 272,
+  height = 128,
+  pattern = "placeholder.floor.high",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 32,
+  width = 96,
+  height = 8,
+  pattern = "wall_border.high.n",
+}
+
+tile{
+  layer = 1,
+  x = 8,
+  y = 8,
+  width = 24,
+  height = 24,
+  pattern = "high_wall_inner_corner.nw",
+}
+
+tile{
+  layer = 1,
+  x = 288,
+  y = 8,
+  width = 24,
+  height = 24,
+  pattern = "high_wall_inner_corner.ne",
+}
+
+tile{
+  layer = 1,
+  x = 8,
+  y = 208,
+  width = 24,
+  height = 24,
+  pattern = "high_wall_inner_corner.sw",
+}
+
+tile{
+  layer = 1,
+  x = 288,
+  y = 208,
+  width = 24,
+  height = 24,
+  pattern = "high_wall_inner_corner.se",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 8,
+  width = 96,
+  height = 24,
+  pattern = "high_wall.n",
+}
+
+tile{
+  layer = 1,
+  x = 192,
+  y = 8,
+  width = 96,
+  height = 24,
+  pattern = "high_wall.n",
+}
+
+tile{
+  layer = 1,
+  x = 8,
+  y = 144,
+  width = 24,
+  height = 64,
+  pattern = "high_wall.w",
+}
+
+tile{
+  layer = 1,
+  x = 8,
+  y = 32,
+  width = 24,
+  height = 64,
+  pattern = "high_wall.w",
+}
+
+tile{
+  layer = 1,
+  x = 288,
+  y = 32,
+  width = 24,
+  height = 64,
+  pattern = "high_wall.e",
+}
+
+tile{
+  layer = 1,
+  x = 288,
+  y = 144,
+  width = 24,
+  height = 64,
+  pattern = "high_wall.e",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 208,
+  width = 256,
+  height = 24,
+  pattern = "high_wall.s",
+}
+
+tile{
+  layer = 1,
+  x = 192,
+  y = 32,
+  width = 96,
+  height = 8,
+  pattern = "wall_border.high.n",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 32,
+  width = 8,
+  height = 112,
+  pattern = "wall_border.high.w",
+}
+
+tile{
+  layer = 1,
+  x = 280,
+  y = 32,
+  width = 8,
+  height = 112,
+  pattern = "wall_border.high.e",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 32,
+  width = 8,
+  height = 8,
+  pattern = "wall_border_inner_corner.high.nw",
+}
+
+tile{
+  layer = 1,
+  x = 280,
+  y = 32,
+  width = 8,
+  height = 8,
+  pattern = "wall_border_inner_corner.high.ne",
+}
+
+tile{
+  layer = 1,
   x = 120,
-  y = 40,
+  y = 32,
   width = 8,
   height = 112,
   pattern = "wall_border.high.e",
@@ -21,7 +183,7 @@ tile{
 tile{
   layer = 1,
   x = 192,
-  y = 40,
+  y = 32,
   width = 8,
   height = 112,
   pattern = "wall_border.high.w",
@@ -415,90 +577,90 @@ tile{
 }
 
 dynamic_tile{
+  name = "treasure_obstacle_canvas2_3",
   layer = 1,
   x = 216,
   y = 56,
+  pattern = "carpet_border",
   width = 48,
   height = 48,
-  name = "treasure_obstacle_canvas2_3",
-  pattern = "carpet_border",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "treasure_open_canvas2_3",
   layer = 1,
   x = 56,
   y = 56,
+  pattern = "carpet_border",
   width = 48,
   height = 48,
-  name = "treasure_open_canvas2_3",
-  pattern = "carpet_border",
   enabled_at_start = true,
 }
 
 dynamic_tile{
-  layer = 1,
-  x = 64,
-  y = 64,
-  width = 32,
-  height = 32,
   name = "treasure_open_canvas1_3",
+  layer = 1,
+  x = 64,
+  y = 64,
   pattern = "carpet.1",
+  width = 32,
+  height = 32,
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "treasure_obstacle_canvas1_3",
   layer = 1,
   x = 224,
   y = 64,
+  pattern = "carpet.1",
   width = 32,
   height = 32,
-  name = "treasure_obstacle_canvas1_3",
-  pattern = "carpet.1",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "treasure_open_chest",
   layer = 1,
   x = 72,
   y = 72,
+  pattern = "placeholder.treasure_open",
   width = 16,
   height = 16,
-  name = "treasure_open_chest",
-  pattern = "placeholder.treasure_open",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "treasure_obstacle_chest",
   layer = 1,
   x = 232,
   y = 72,
+  pattern = "placeholder.treasure_obstacle",
   width = 16,
   height = 16,
-  name = "treasure_obstacle_chest",
-  pattern = "placeholder.treasure_obstacle",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "enemy_4",
   layer = 1,
   x = 64,
   y = 104,
+  pattern = "placeholder.enemy",
   width = 32,
   height = 32,
-  name = "enemy_4",
-  pattern = "placeholder.enemy",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "enemy_2",
   layer = 1,
   x = 224,
   y = 104,
+  pattern = "placeholder.enemy",
   width = 32,
   height = 32,
-  name = "enemy_2",
-  pattern = "placeholder.enemy",
   enabled_at_start = true,
 }
 
@@ -520,4 +682,39 @@ wall{
   stops_enemies = true,
 }
 
+tile{
+  layer = 2,
+  x = 0,
+  y = 0,
+  width = 320,
+  height = 8,
+  pattern = "ceiling",
+}
+
+tile{
+  layer = 2,
+  x = 0,
+  y = 232,
+  width = 320,
+  height = 8,
+  pattern = "ceiling",
+}
+
+tile{
+  layer = 2,
+  x = 312,
+  y = 8,
+  width = 8,
+  height = 224,
+  pattern = "ceiling",
+}
+
+tile{
+  layer = 2,
+  x = 0,
+  y = 8,
+  width = 8,
+  height = 224,
+  pattern = "ceiling",
+}
 

--- a/data/maps/components/obstacle_glove/obstacle_glove_e_010333_2.dat
+++ b/data/maps/components/obstacle_glove/obstacle_glove_e_010333_2.dat
@@ -10,21 +10,39 @@ properties{
 }
 
 tile{
-  layer = 1,
+  layer = 0,
   x = 184,
-  y = 136,
+  y = 32,
   width = 80,
-  height = 72,
+  height = 184,
   pattern = "hole",
 }
 
 tile{
   layer = 1,
-  x = 184,
+  x = 264,
+  y = 24,
+  width = 32,
+  height = 192,
+  pattern = "placeholder.floor.high",
+}
+
+tile{
+  layer = 1,
+  x = 288,
   y = 32,
-  width = 80,
-  height = 72,
-  pattern = "hole",
+  width = 24,
+  height = 64,
+  pattern = "high_wall.e",
+}
+
+tile{
+  layer = 1,
+  x = 288,
+  y = 144,
+  width = 24,
+  height = 64,
+  pattern = "high_wall.e",
 }
 
 tile{
@@ -153,59 +171,202 @@ tile{
   pattern = "hole_border_inner_corner.sw",
 }
 
+tile{
+  layer = 1,
+  x = 288,
+  y = 8,
+  width = 24,
+  height = 24,
+  pattern = "high_wall_inner_corner.ne",
+}
+
+tile{
+  layer = 1,
+  x = 288,
+  y = 208,
+  width = 24,
+  height = 24,
+  pattern = "high_wall_inner_corner.se",
+}
+
+tile{
+  layer = 1,
+  x = 192,
+  y = 208,
+  width = 96,
+  height = 24,
+  pattern = "high_wall.s",
+}
+
+tile{
+  layer = 1,
+  x = 192,
+  y = 8,
+  width = 96,
+  height = 24,
+  pattern = "high_wall.n",
+}
+
+tile{
+  layer = 1,
+  x = 136,
+  y = 24,
+  width = 48,
+  height = 192,
+  pattern = "placeholder.floor.high",
+}
+
+tile{
+  layer = 1,
+  x = 184,
+  y = 104,
+  width = 80,
+  height = 32,
+  pattern = "placeholder.floor.high",
+}
+
+tile{
+  layer = 1,
+  x = 272,
+  y = 200,
+  width = 16,
+  height = 8,
+  pattern = "wall_border.high.s",
+}
+
+tile{
+  layer = 1,
+  x = 144,
+  y = 200,
+  width = 32,
+  height = 8,
+  pattern = "wall_border.high.s",
+}
+
+tile{
+  layer = 1,
+  x = 144,
+  y = 32,
+  width = 32,
+  height = 8,
+  pattern = "wall_border.high.n",
+}
+
+tile{
+  layer = 1,
+  x = 272,
+  y = 32,
+  width = 16,
+  height = 8,
+  pattern = "wall_border.high.n",
+}
+
+tile{
+  layer = 1,
+  x = 280,
+  y = 32,
+  width = 8,
+  height = 176,
+  pattern = "wall_border.high.e",
+}
+
+tile{
+  layer = 1,
+  x = 280,
+  y = 32,
+  width = 8,
+  height = 8,
+  pattern = "wall_border_inner_corner.high.ne",
+}
+
+tile{
+  layer = 1,
+  x = 280,
+  y = 200,
+  width = 8,
+  height = 8,
+  pattern = "wall_border_inner_corner.high.se",
+}
+
 dynamic_tile{
+  name = "stone_1",
   layer = 1,
   x = 176,
   y = 104,
+  pattern = "placeholder.stone",
   width = 16,
   height = 16,
-  name = "stone_1",
-  pattern = "placeholder.stone",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "stone_2",
   layer = 1,
   x = 176,
   y = 120,
+  pattern = "placeholder.stone",
   width = 16,
   height = 16,
-  name = "stone_2",
-  pattern = "placeholder.stone",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "treasure_open_chest",
   layer = 1,
   x = 152,
   y = 56,
+  pattern = "placeholder.treasure_open",
   width = 16,
   height = 16,
-  name = "treasure_open_chest",
-  pattern = "placeholder.treasure_open",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "treasure_obstacle_chest",
   layer = 1,
   x = 264,
   y = 40,
+  pattern = "placeholder.treasure_obstacle",
   width = 16,
   height = 16,
-  name = "treasure_obstacle_chest",
-  pattern = "placeholder.treasure_obstacle",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "enemy_2",
   layer = 1,
   x = 144,
   y = 104,
+  pattern = "placeholder.enemy",
   width = 32,
   height = 32,
-  name = "enemy_2",
-  pattern = "placeholder.enemy",
   enabled_at_start = true,
 }
 
+tile{
+  layer = 2,
+  x = 136,
+  y = 0,
+  width = 184,
+  height = 8,
+  pattern = "ceiling",
+}
+
+tile{
+  layer = 2,
+  x = 312,
+  y = 8,
+  width = 8,
+  height = 224,
+  pattern = "ceiling",
+}
+
+tile{
+  layer = 2,
+  x = 136,
+  y = 232,
+  width = 184,
+  height = 8,
+  pattern = "ceiling",
+}
 

--- a/data/maps/components/obstacle_glove/obstacle_glove_sw_042777_4.dat
+++ b/data/maps/components/obstacle_glove/obstacle_glove_sw_042777_4.dat
@@ -11,6 +11,87 @@ properties{
 
 tile{
   layer = 1,
+  x = 24,
+  y = 24,
+  width = 272,
+  height = 192,
+  pattern = "placeholder.floor.high",
+}
+
+tile{
+  layer = 1,
+  x = 8,
+  y = 32,
+  width = 24,
+  height = 64,
+  pattern = "high_wall.w",
+}
+
+tile{
+  layer = 1,
+  x = 8,
+  y = 144,
+  width = 24,
+  height = 64,
+  pattern = "high_wall.w",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 208,
+  width = 96,
+  height = 24,
+  pattern = "high_wall.s",
+}
+
+tile{
+  layer = 1,
+  x = 192,
+  y = 208,
+  width = 96,
+  height = 24,
+  pattern = "high_wall.s",
+}
+
+tile{
+  layer = 1,
+  x = 288,
+  y = 144,
+  width = 24,
+  height = 64,
+  pattern = "high_wall.e",
+}
+
+tile{
+  layer = 1,
+  x = 288,
+  y = 32,
+  width = 24,
+  height = 64,
+  pattern = "high_wall.e",
+}
+
+tile{
+  layer = 1,
+  x = 192,
+  y = 8,
+  width = 96,
+  height = 24,
+  pattern = "high_wall.n",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 8,
+  width = 96,
+  height = 24,
+  pattern = "high_wall.n",
+}
+
+tile{
+  layer = 1,
   x = 184,
   y = 104,
   width = 48,
@@ -261,92 +342,253 @@ tile{
   pattern = "hole_border_outer_corner.ne",
 }
 
+tile{
+  layer = 1,
+  x = 8,
+  y = 8,
+  width = 24,
+  height = 24,
+  pattern = "high_wall_inner_corner.nw",
+}
+
+tile{
+  layer = 1,
+  x = 288,
+  y = 8,
+  width = 24,
+  height = 24,
+  pattern = "high_wall_inner_corner.ne",
+}
+
+tile{
+  layer = 1,
+  x = 8,
+  y = 208,
+  width = 24,
+  height = 24,
+  pattern = "high_wall_inner_corner.sw",
+}
+
+tile{
+  layer = 1,
+  x = 288,
+  y = 208,
+  width = 24,
+  height = 24,
+  pattern = "high_wall_inner_corner.se",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 32,
+  width = 48,
+  height = 8,
+  pattern = "wall_border.high.n",
+}
+
+tile{
+  layer = 1,
+  x = 144,
+  y = 32,
+  width = 144,
+  height = 8,
+  pattern = "wall_border.high.n",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 200,
+  width = 144,
+  height = 8,
+  pattern = "wall_border.high.s",
+}
+
+tile{
+  layer = 1,
+  x = 240,
+  y = 200,
+  width = 48,
+  height = 8,
+  pattern = "wall_border.high.s",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 32,
+  width = 8,
+  height = 176,
+  pattern = "wall_border.high.w",
+}
+
+tile{
+  layer = 1,
+  x = 280,
+  y = 32,
+  width = 8,
+  height = 176,
+  pattern = "wall_border.high.e",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 200,
+  width = 8,
+  height = 8,
+  pattern = "wall_border_inner_corner.high.sw",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 32,
+  width = 8,
+  height = 8,
+  pattern = "wall_border_inner_corner.high.nw",
+}
+
+tile{
+  layer = 1,
+  x = 280,
+  y = 32,
+  width = 8,
+  height = 8,
+  pattern = "wall_border_inner_corner.high.ne",
+}
+
+tile{
+  layer = 1,
+  x = 280,
+  y = 200,
+  width = 8,
+  height = 8,
+  pattern = "wall_border_inner_corner.high.se",
+}
+
 dynamic_tile{
+  name = "stone_3",
   layer = 1,
   x = 184,
   y = 136,
+  pattern = "placeholder.stone",
   width = 16,
   height = 16,
-  name = "stone_3",
-  pattern = "placeholder.stone",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "stone_2",
   layer = 1,
   x = 216,
   y = 136,
+  pattern = "placeholder.stone",
   width = 16,
   height = 16,
-  name = "stone_2",
-  pattern = "placeholder.stone",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "enemy_7",
   layer = 1,
   x = 40,
   y = 168,
+  pattern = "placeholder.enemy",
   width = 32,
   height = 32,
-  name = "enemy_7",
-  pattern = "placeholder.enemy",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "enemy_2",
   layer = 1,
   x = 136,
   y = 168,
+  pattern = "placeholder.enemy",
   width = 32,
   height = 32,
-  name = "enemy_2",
-  pattern = "placeholder.enemy",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "enemy_3",
   layer = 1,
   x = 240,
   y = 88,
+  pattern = "placeholder.enemy",
   width = 32,
   height = 32,
-  name = "enemy_3",
-  pattern = "placeholder.enemy",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "enemy_4",
   layer = 1,
   x = 240,
   y = 168,
+  pattern = "placeholder.enemy",
   width = 32,
   height = 32,
-  name = "enemy_4",
-  pattern = "placeholder.enemy",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "treasure_obstacle_chest",
   layer = 1,
   x = 56,
   y = 56,
+  pattern = "placeholder.treasure_obstacle",
   width = 16,
   height = 16,
-  name = "treasure_obstacle_chest",
-  pattern = "placeholder.treasure_obstacle",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "treasure_open_chest",
   layer = 1,
   x = 264,
   y = 40,
+  pattern = "placeholder.treasure_open",
   width = 16,
   height = 16,
-  name = "treasure_open_chest",
-  pattern = "placeholder.treasure_open",
   enabled_at_start = true,
 }
 
+tile{
+  layer = 2,
+  x = 0,
+  y = 0,
+  width = 320,
+  height = 8,
+  pattern = "ceiling",
+}
+
+tile{
+  layer = 2,
+  x = 0,
+  y = 232,
+  width = 320,
+  height = 8,
+  pattern = "ceiling",
+}
+
+tile{
+  layer = 2,
+  x = 0,
+  y = 8,
+  width = 8,
+  height = 224,
+  pattern = "ceiling",
+}
+
+tile{
+  layer = 2,
+  x = 312,
+  y = 8,
+  width = 8,
+  height = 224,
+  pattern = "ceiling",
+}
 

--- a/data/maps/components/obstacle_hookshot/obstacle_hookshot_ew_050777_2.dat
+++ b/data/maps/components/obstacle_hookshot/obstacle_hookshot_ew_050777_2.dat
@@ -11,6 +11,159 @@ properties{
 
 tile{
   layer = 1,
+  x = 24,
+  y = 24,
+  width = 272,
+  height = 192,
+  pattern = "placeholder.floor.high",
+}
+
+tile{
+  layer = 1,
+  x = 8,
+  y = 8,
+  width = 24,
+  height = 24,
+  pattern = "high_wall_inner_corner.nw",
+}
+
+tile{
+  layer = 1,
+  x = 288,
+  y = 8,
+  width = 24,
+  height = 24,
+  pattern = "high_wall_inner_corner.ne",
+}
+
+tile{
+  layer = 1,
+  x = 8,
+  y = 208,
+  width = 24,
+  height = 24,
+  pattern = "high_wall_inner_corner.sw",
+}
+
+tile{
+  layer = 1,
+  x = 288,
+  y = 208,
+  width = 24,
+  height = 24,
+  pattern = "high_wall_inner_corner.se",
+}
+
+tile{
+  layer = 1,
+  x = 8,
+  y = 144,
+  width = 24,
+  height = 64,
+  pattern = "high_wall.w",
+}
+
+tile{
+  layer = 1,
+  x = 8,
+  y = 32,
+  width = 24,
+  height = 64,
+  pattern = "high_wall.w",
+}
+
+tile{
+  layer = 1,
+  x = 288,
+  y = 32,
+  width = 24,
+  height = 64,
+  pattern = "high_wall.e",
+}
+
+tile{
+  layer = 1,
+  x = 288,
+  y = 144,
+  width = 24,
+  height = 64,
+  pattern = "high_wall.e",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 32,
+  width = 256,
+  height = 8,
+  pattern = "wall_border.high.n",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 200,
+  width = 256,
+  height = 8,
+  pattern = "wall_border.high.s",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 32,
+  width = 8,
+  height = 176,
+  pattern = "wall_border.high.w",
+}
+
+tile{
+  layer = 1,
+  x = 280,
+  y = 32,
+  width = 8,
+  height = 176,
+  pattern = "wall_border.high.e",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 32,
+  width = 8,
+  height = 8,
+  pattern = "wall_border_inner_corner.high.nw",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 200,
+  width = 8,
+  height = 8,
+  pattern = "wall_border_inner_corner.high.sw",
+}
+
+tile{
+  layer = 1,
+  x = 280,
+  y = 200,
+  width = 8,
+  height = 8,
+  pattern = "wall_border_inner_corner.high.se",
+}
+
+tile{
+  layer = 1,
+  x = 280,
+  y = 32,
+  width = 8,
+  height = 8,
+  pattern = "wall_border_inner_corner.high.ne",
+}
+
+tile{
+  layer = 1,
   x = 88,
   y = 32,
   width = 48,
@@ -171,11 +324,46 @@ tile{
   pattern = "wall_torch.e",
 }
 
+tile{
+  layer = 1,
+  x = 32,
+  y = 8,
+  width = 96,
+  height = 24,
+  pattern = "high_wall.n",
+}
+
+tile{
+  layer = 1,
+  x = 192,
+  y = 8,
+  width = 96,
+  height = 24,
+  pattern = "high_wall.n",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 208,
+  width = 96,
+  height = 24,
+  pattern = "high_wall.s",
+}
+
+tile{
+  layer = 1,
+  x = 192,
+  y = 208,
+  width = 96,
+  height = 24,
+  pattern = "high_wall.s",
+}
+
 block{
   layer = 1,
   x = 64,
   y = 197,
-  direction = -1,
   sprite = "entities/block",
   pushable = false,
   pullable = false,
@@ -183,124 +371,159 @@ block{
 }
 
 dynamic_tile{
+  name = "treasure_obstacle_chest",
   layer = 1,
   x = 248,
   y = 40,
+  pattern = "placeholder.treasure_obstacle",
   width = 16,
   height = 16,
-  name = "treasure_obstacle_chest",
-  pattern = "placeholder.treasure_obstacle",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "treasure_open_chest",
   layer = 1,
   x = 152,
   y = 112,
+  pattern = "placeholder.treasure_block",
   width = 16,
   height = 16,
-  name = "treasure_open_chest",
-  pattern = "placeholder.treasure_block",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "enemy_1",
   layer = 1,
   x = 40,
   y = 96,
+  pattern = "placeholder.enemy",
   width = 32,
   height = 32,
-  name = "enemy_1",
-  pattern = "placeholder.enemy",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "enemy_2",
   layer = 1,
   x = 144,
   y = 152,
+  pattern = "placeholder.enemy",
   width = 32,
   height = 32,
-  name = "enemy_2",
-  pattern = "placeholder.enemy",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "enemy_3",
   layer = 1,
   x = 248,
   y = 72,
+  pattern = "placeholder.enemy",
   width = 32,
   height = 32,
-  name = "enemy_3",
-  pattern = "placeholder.enemy",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "pot_1",
   layer = 1,
   x = 40,
   y = 40,
+  pattern = "placeholder.pot",
   width = 16,
   height = 16,
-  name = "pot_1",
-  pattern = "placeholder.pot",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "pot_2",
   layer = 1,
   x = 40,
   y = 56,
+  pattern = "placeholder.pot",
   width = 16,
   height = 16,
-  name = "pot_2",
-  pattern = "placeholder.pot",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "pot_3",
   layer = 1,
   x = 56,
   y = 40,
+  pattern = "placeholder.pot",
   width = 16,
   height = 16,
-  name = "pot_3",
-  pattern = "placeholder.pot",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "pot_4",
   layer = 1,
   x = 248,
   y = 184,
+  pattern = "placeholder.pot",
   width = 16,
   height = 16,
-  name = "pot_4",
-  pattern = "placeholder.pot",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "pot_5",
   layer = 1,
   x = 264,
   y = 184,
+  pattern = "placeholder.pot",
   width = 16,
   height = 16,
-  name = "pot_5",
-  pattern = "placeholder.pot",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "pot_6",
   layer = 1,
   x = 264,
   y = 168,
+  pattern = "placeholder.pot",
   width = 16,
   height = 16,
-  name = "pot_6",
-  pattern = "placeholder.pot",
   enabled_at_start = true,
 }
 
+tile{
+  layer = 2,
+  x = 0,
+  y = 0,
+  width = 320,
+  height = 8,
+  pattern = "ceiling",
+}
+
+tile{
+  layer = 2,
+  x = 0,
+  y = 232,
+  width = 320,
+  height = 8,
+  pattern = "ceiling",
+}
+
+tile{
+  layer = 2,
+  x = 312,
+  y = 8,
+  width = 8,
+  height = 224,
+  pattern = "ceiling",
+}
+
+tile{
+  layer = 2,
+  x = 0,
+  y = 8,
+  width = 8,
+  height = 224,
+  pattern = "ceiling",
+}
 

--- a/data/maps/components/obstacle_lamp/obstacle_lamp_nsew_000777_lampbow.dat
+++ b/data/maps/components/obstacle_lamp/obstacle_lamp_nsew_000777_lampbow.dat
@@ -11,230 +11,435 @@ properties{
 
 tile{
   layer = 1,
-  x = 144,
-  y = 104,
-  width = 32,
-  height = 24,
-  pattern = "bow_target.top",
+  x = 24,
+  y = 24,
+  width = 272,
+  height = 192,
+  pattern = "placeholder.floor.high",
 }
 
 tile{
   layer = 1,
-  x = 144,
-  y = 128,
-  width = 32,
+  x = 8,
+  y = 8,
+  width = 24,
+  height = 24,
+  pattern = "high_wall_inner_corner.nw",
+}
+
+tile{
+  layer = 1,
+  x = 288,
+  y = 8,
+  width = 24,
+  height = 24,
+  pattern = "high_wall_inner_corner.ne",
+}
+
+tile{
+  layer = 1,
+  x = 288,
+  y = 208,
+  width = 24,
+  height = 24,
+  pattern = "high_wall_inner_corner.se",
+}
+
+tile{
+  layer = 1,
+  x = 8,
+  y = 208,
+  width = 24,
+  height = 24,
+  pattern = "high_wall_inner_corner.sw",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 8,
+  width = 96,
+  height = 24,
+  pattern = "high_wall.n",
+}
+
+tile{
+  layer = 1,
+  x = 192,
+  y = 8,
+  width = 96,
+  height = 24,
+  pattern = "high_wall.n",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 208,
+  width = 96,
+  height = 24,
+  pattern = "high_wall.s",
+}
+
+tile{
+  layer = 1,
+  x = 192,
+  y = 208,
+  width = 96,
+  height = 24,
+  pattern = "high_wall.s",
+}
+
+tile{
+  layer = 1,
+  x = 288,
+  y = 32,
+  width = 24,
+  height = 64,
+  pattern = "high_wall.e",
+}
+
+tile{
+  layer = 1,
+  x = 288,
+  y = 144,
+  width = 24,
+  height = 64,
+  pattern = "high_wall.e",
+}
+
+tile{
+  layer = 1,
+  x = 8,
+  y = 32,
+  width = 24,
+  height = 64,
+  pattern = "high_wall.w",
+}
+
+tile{
+  layer = 1,
+  x = 8,
+  y = 144,
+  width = 24,
+  height = 64,
+  pattern = "high_wall.w",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 32,
+  width = 256,
   height = 8,
-  pattern = "bow_target.bottom",
+  pattern = "wall_border.high.n",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 200,
+  width = 256,
+  height = 8,
+  pattern = "wall_border.high.s",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 32,
+  width = 8,
+  height = 176,
+  pattern = "wall_border.high.w",
+}
+
+tile{
+  layer = 1,
+  x = 280,
+  y = 32,
+  width = 8,
+  height = 176,
+  pattern = "wall_border.high.e",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 32,
+  width = 8,
+  height = 8,
+  pattern = "wall_border_inner_corner.high.nw",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 200,
+  width = 8,
+  height = 8,
+  pattern = "wall_border_inner_corner.high.sw",
+}
+
+tile{
+  layer = 1,
+  x = 280,
+  y = 200,
+  width = 8,
+  height = 8,
+  pattern = "wall_border_inner_corner.high.se",
+}
+
+tile{
+  layer = 1,
+  x = 280,
+  y = 32,
+  width = 8,
+  height = 8,
+  pattern = "wall_border_inner_corner.high.ne",
 }
 
 dynamic_tile{
+  name = "enemy_5",
   layer = 1,
   x = 80,
   y = 104,
+  pattern = "placeholder.enemy",
   width = 32,
   height = 32,
-  name = "enemy_5",
-  pattern = "placeholder.enemy",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "treasure_open_chest",
   layer = 1,
   x = 248,
   y = 40,
+  pattern = "placeholder.treasure_open",
   width = 16,
   height = 16,
-  name = "treasure_open_chest",
-  pattern = "placeholder.treasure_open",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "treasure_obstacle_chest",
   layer = 1,
   x = 56,
   y = 40,
+  pattern = "placeholder.treasure_obstacle",
   width = 16,
   height = 16,
-  name = "treasure_obstacle_chest",
-  pattern = "placeholder.treasure_obstacle",
   enabled_at_start = true,
 }
 
-wall{
-  layer = 1,
-  x = 144,
-  y = 128,
-  width = 32,
-  height = 8,
-  stops_hero = true,
-  stops_enemies = true,
-  stops_npcs = true,
-  stops_blocks = true,
-}
-
 custom_entity{
-  layer = 1,
-  x = 208,
-  y = 85,
-  width = 16,
-  height = 16,
   name = "torch_5",
+  layer = 1,
+  x = 208,
+  y = 85,
+  width = 16,
+  height = 16,
   direction = 3,
   model = "torch",
 }
 
 custom_entity{
+  name = "torch_2",
   layer = 1,
   x = 112,
   y = 85,
   width = 16,
   height = 16,
-  name = "torch_2",
   direction = 3,
   model = "torch",
 }
 
 custom_entity{
+  name = "torch_3",
   layer = 1,
   x = 208,
   y = 165,
   width = 16,
   height = 16,
-  name = "torch_3",
   direction = 3,
   model = "torch",
 }
 
 custom_entity{
+  name = "torch_4",
   layer = 1,
   x = 112,
   y = 165,
   width = 16,
   height = 16,
-  name = "torch_4",
   direction = 3,
   model = "torch",
 }
 
 dynamic_tile{
+  name = "enemy_2",
   layer = 1,
   x = 208,
   y = 104,
+  pattern = "placeholder.enemy",
   width = 32,
   height = 32,
-  name = "enemy_2",
-  pattern = "placeholder.enemy",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "enemy_3",
   layer = 1,
   x = 144,
   y = 48,
+  pattern = "placeholder.enemy",
   width = 32,
   height = 32,
-  name = "enemy_3",
-  pattern = "placeholder.enemy",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "enemy_4",
   layer = 1,
   x = 144,
   y = 160,
+  pattern = "placeholder.enemy",
   width = 32,
   height = 32,
-  name = "enemy_4",
-  pattern = "placeholder.enemy",
   enabled_at_start = true,
 }
 
 dynamic_tile{
-  layer = 1,
-  x = 40,
-  y = 40,
-  width = 16,
-  height = 16,
   name = "stone_3",
+  layer = 1,
+  x = 40,
+  y = 40,
   pattern = "placeholder.stone",
+  width = 16,
+  height = 16,
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "stone_2",
   layer = 1,
   x = 264,
   y = 40,
+  pattern = "placeholder.stone",
   width = 16,
   height = 16,
-  name = "stone_2",
-  pattern = "placeholder.stone",
   enabled_at_start = true,
 }
 
 dynamic_tile{
-  layer = 1,
-  x = 264,
-  y = 184,
-  width = 16,
-  height = 16,
   name = "stone_4",
+  layer = 1,
+  x = 264,
+  y = 184,
   pattern = "placeholder.stone",
+  width = 16,
+  height = 16,
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "stone_5",
   layer = 1,
   x = 40,
   y = 184,
-  width = 16,
-  height = 16,
-  name = "stone_5",
   pattern = "placeholder.stone",
+  width = 16,
+  height = 16,
   enabled_at_start = true,
 }
 
 dynamic_tile{
-  layer = 1,
-  x = 40,
-  y = 56,
-  width = 16,
-  height = 16,
   name = "pot_5",
+  layer = 1,
+  x = 40,
+  y = 56,
   pattern = "placeholder.pot",
+  width = 16,
+  height = 16,
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "pot_2",
   layer = 1,
   x = 40,
   y = 168,
+  pattern = "placeholder.pot",
   width = 16,
   height = 16,
-  name = "pot_2",
-  pattern = "placeholder.pot",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "pot_3",
   layer = 1,
   x = 264,
   y = 168,
+  pattern = "placeholder.pot",
   width = 16,
   height = 16,
-  name = "pot_3",
-  pattern = "placeholder.pot",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "pot_4",
   layer = 1,
   x = 264,
   y = 56,
+  pattern = "placeholder.pot",
   width = 16,
   height = 16,
-  name = "pot_4",
-  pattern = "placeholder.pot",
   enabled_at_start = true,
 }
 
+dynamic_tile{
+  name = "switch",
+  layer = 1,
+  x = 144,
+  y = 104,
+  pattern = "placeholder.target_statue",
+  width = 32,
+  height = 32,
+  enabled_at_start = true,
+}
+
+tile{
+  layer = 2,
+  x = 0,
+  y = 0,
+  width = 320,
+  height = 8,
+  pattern = "ceiling",
+}
+
+tile{
+  layer = 2,
+  x = 0,
+  y = 232,
+  width = 320,
+  height = 8,
+  pattern = "ceiling",
+}
+
+tile{
+  layer = 2,
+  x = 0,
+  y = 8,
+  width = 8,
+  height = 224,
+  pattern = "ceiling",
+}
+
+tile{
+  layer = 2,
+  x = 312,
+  y = 8,
+  width = 8,
+  height = 224,
+  pattern = "ceiling",
+}
 

--- a/data/maps/components/obstacle_puzzle/obstacle_puzzle_nsew_000001_2.dat
+++ b/data/maps/components/obstacle_puzzle/obstacle_puzzle_nsew_000001_2.dat
@@ -11,6 +11,15 @@ properties{
 
 tile{
   layer = 1,
+  x = 184,
+  y = 136,
+  width = 112,
+  height = 80,
+  pattern = "placeholder.floor.high",
+}
+
+tile{
+  layer = 1,
   x = 232,
   y = 184,
   width = 16,
@@ -18,11 +27,65 @@ tile{
   pattern = "block",
 }
 
+tile{
+  layer = 1,
+  x = 288,
+  y = 208,
+  width = 24,
+  height = 24,
+  pattern = "high_wall_inner_corner.se",
+}
+
+tile{
+  layer = 1,
+  x = 288,
+  y = 144,
+  width = 24,
+  height = 64,
+  pattern = "high_wall.e",
+}
+
+tile{
+  layer = 1,
+  x = 192,
+  y = 208,
+  width = 96,
+  height = 24,
+  pattern = "high_wall.s",
+}
+
+tile{
+  layer = 1,
+  x = 280,
+  y = 144,
+  width = 8,
+  height = 64,
+  pattern = "wall_border.high.e",
+}
+
+tile{
+  layer = 1,
+  x = 192,
+  y = 200,
+  width = 96,
+  height = 8,
+  pattern = "wall_border.high.s",
+}
+
+tile{
+  layer = 1,
+  x = 280,
+  y = 200,
+  width = 8,
+  height = 8,
+  pattern = "wall_border_inner_corner.high.se",
+}
+
 switch{
+  name = "switch",
   layer = 1,
   x = 0,
   y = 0,
-  name = "switch",
   subtype = "walkable",
   sprite = "entities/switch",
   needs_block = false,
@@ -30,11 +93,10 @@ switch{
 }
 
 block{
+  name = "block_1",
   layer = 1,
   x = 224,
   y = 181,
-  name = "block_1",
-  direction = -1,
   sprite = "entities/block",
   pushable = true,
   pullable = false,
@@ -42,11 +104,10 @@ block{
 }
 
 block{
+  name = "block_2",
   layer = 1,
   x = 256,
   y = 165,
-  name = "block_2",
-  direction = -1,
   sprite = "entities/block",
   pushable = true,
   pullable = false,
@@ -54,36 +115,53 @@ block{
 }
 
 dynamic_tile{
+  name = "enemy_1",
   layer = 1,
   x = 200,
   y = 136,
+  pattern = "placeholder.enemy",
   width = 32,
   height = 32,
-  name = "enemy_1",
-  pattern = "placeholder.enemy",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "treasure_obstacle_chest",
   layer = 1,
   x = 184,
   y = 168,
+  pattern = "placeholder.treasure_puzzle",
   width = 16,
   height = 16,
-  name = "treasure_obstacle_chest",
-  pattern = "placeholder.treasure_puzzle",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "treasure_open_chest",
   layer = 1,
   x = 184,
   y = 136,
+  pattern = "placeholder.treasure_open",
   width = 16,
   height = 16,
-  name = "treasure_open_chest",
-  pattern = "placeholder.treasure_open",
   enabled_at_start = true,
 }
 
+tile{
+  layer = 2,
+  x = 184,
+  y = 232,
+  width = 136,
+  height = 8,
+  pattern = "ceiling",
+}
+
+tile{
+  layer = 2,
+  x = 312,
+  y = 136,
+  width = 8,
+  height = 96,
+  pattern = "ceiling",
+}
 

--- a/data/maps/components/obstacle_puzzle/obstacle_puzzle_nsew_000003_1.dat
+++ b/data/maps/components/obstacle_puzzle/obstacle_puzzle_nsew_000003_1.dat
@@ -9,77 +9,140 @@ properties{
   music = "same",
 }
 
-dynamic_tile{
+tile{
   layer = 1,
-  x = 216,
-  y = 152,
-  width = 16,
-  height = 16,
+  x = 136,
+  y = 136,
+  width = 160,
+  height = 80,
+  pattern = "placeholder.floor.high",
+}
+
+tile{
+  layer = 1,
+  x = 288,
+  y = 208,
+  width = 24,
+  height = 24,
+  pattern = "high_wall_inner_corner.se",
+}
+
+tile{
+  layer = 1,
+  x = 192,
+  y = 208,
+  width = 96,
+  height = 24,
+  pattern = "high_wall.s",
+}
+
+tile{
+  layer = 1,
+  x = 288,
+  y = 144,
+  width = 24,
+  height = 64,
+  pattern = "high_wall.e",
+}
+
+tile{
+  layer = 1,
+  x = 144,
+  y = 200,
+  width = 144,
+  height = 8,
+  pattern = "wall_border.high.s",
+}
+
+tile{
+  layer = 1,
+  x = 280,
+  y = 144,
+  width = 8,
+  height = 64,
+  pattern = "wall_border.high.e",
+}
+
+tile{
+  layer = 1,
+  x = 280,
+  y = 200,
+  width = 8,
+  height = 8,
+  pattern = "wall_border_inner_corner.high.se",
+}
+
+dynamic_tile{
   name = "pot_1",
+  layer = 1,
+  x = 216,
+  y = 152,
   pattern = "placeholder.pot",
+  width = 16,
+  height = 16,
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "pot_2",
   layer = 1,
   x = 232,
   y = 152,
+  pattern = "placeholder.pot",
   width = 16,
   height = 16,
-  name = "pot_2",
-  pattern = "placeholder.pot",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "pot_3",
   layer = 1,
   x = 248,
   y = 152,
+  pattern = "placeholder.pot",
   width = 16,
   height = 16,
-  name = "pot_3",
-  pattern = "placeholder.pot",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "pot_4",
   layer = 1,
   x = 216,
   y = 168,
+  pattern = "placeholder.pot",
   width = 16,
   height = 16,
-  name = "pot_4",
-  pattern = "placeholder.pot",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "pot_5",
   layer = 1,
   x = 232,
   y = 168,
+  pattern = "placeholder.pot",
   width = 16,
   height = 16,
-  name = "pot_5",
-  pattern = "placeholder.pot",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "pot_6",
   layer = 1,
   x = 248,
   y = 168,
+  pattern = "placeholder.pot",
   width = 16,
   height = 16,
-  name = "pot_6",
-  pattern = "placeholder.pot",
   enabled_at_start = true,
 }
 
 switch{
+  name = "switch",
   layer = 1,
   x = 0,
   y = 0,
-  name = "switch",
   subtype = "walkable",
   sprite = "entities/switch",
   needs_block = false,
@@ -87,36 +150,53 @@ switch{
 }
 
 dynamic_tile{
+  name = "enemy_1",
   layer = 1,
   x = 144,
   y = 136,
+  pattern = "placeholder.enemy",
   width = 32,
   height = 32,
-  name = "enemy_1",
-  pattern = "placeholder.enemy",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "treasure_obstacle_chest",
   layer = 1,
   x = 184,
   y = 136,
+  pattern = "placeholder.treasure_puzzle",
   width = 16,
   height = 16,
-  name = "treasure_obstacle_chest",
-  pattern = "placeholder.treasure_puzzle",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "treasure_open_chest",
   layer = 1,
   x = 184,
   y = 168,
+  pattern = "placeholder.treasure_open",
   width = 16,
   height = 16,
-  name = "treasure_open_chest",
-  pattern = "placeholder.treasure_open",
   enabled_at_start = true,
 }
 
+tile{
+  layer = 2,
+  x = 136,
+  y = 232,
+  width = 184,
+  height = 8,
+  pattern = "ceiling",
+}
+
+tile{
+  layer = 2,
+  x = 312,
+  y = 136,
+  width = 8,
+  height = 96,
+  pattern = "ceiling",
+}
 

--- a/data/maps/components/obstacle_puzzle/obstacle_puzzle_nsew_000006_1.dat
+++ b/data/maps/components/obstacle_puzzle/obstacle_puzzle_nsew_000006_1.dat
@@ -9,77 +9,140 @@ properties{
   music = "same",
 }
 
-dynamic_tile{
+tile{
   layer = 1,
-  x = 56,
-  y = 152,
-  width = 16,
-  height = 16,
+  x = 24,
+  y = 136,
+  width = 160,
+  height = 80,
+  pattern = "placeholder.floor.high",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 200,
+  width = 96,
+  height = 8,
+  pattern = "wall_border.high.s",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 144,
+  width = 8,
+  height = 64,
+  pattern = "wall_border.high.w",
+}
+
+tile{
+  layer = 1,
+  x = 8,
+  y = 208,
+  width = 24,
+  height = 24,
+  pattern = "high_wall_inner_corner.sw",
+}
+
+tile{
+  layer = 1,
+  x = 8,
+  y = 144,
+  width = 24,
+  height = 64,
+  pattern = "high_wall.w",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 208,
+  width = 96,
+  height = 24,
+  pattern = "high_wall.s",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 200,
+  width = 8,
+  height = 8,
+  pattern = "wall_border_inner_corner.high.sw",
+}
+
+dynamic_tile{
   name = "pot_7",
+  layer = 1,
+  x = 56,
+  y = 152,
   pattern = "placeholder.pot",
+  width = 16,
+  height = 16,
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "pot_2",
   layer = 1,
   x = 72,
   y = 152,
+  pattern = "placeholder.pot",
   width = 16,
   height = 16,
-  name = "pot_2",
-  pattern = "placeholder.pot",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "pot_3",
   layer = 1,
   x = 88,
   y = 152,
+  pattern = "placeholder.pot",
   width = 16,
   height = 16,
-  name = "pot_3",
-  pattern = "placeholder.pot",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "pot_4",
   layer = 1,
   x = 56,
   y = 168,
+  pattern = "placeholder.pot",
   width = 16,
   height = 16,
-  name = "pot_4",
-  pattern = "placeholder.pot",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "pot_5",
   layer = 1,
   x = 72,
   y = 168,
+  pattern = "placeholder.pot",
   width = 16,
   height = 16,
-  name = "pot_5",
-  pattern = "placeholder.pot",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "pot_6",
   layer = 1,
   x = 88,
   y = 168,
+  pattern = "placeholder.pot",
   width = 16,
   height = 16,
-  name = "pot_6",
-  pattern = "placeholder.pot",
   enabled_at_start = true,
 }
 
 switch{
+  name = "switch",
   layer = 1,
   x = 0,
   y = 0,
-  name = "switch",
   subtype = "walkable",
   sprite = "entities/switch",
   needs_block = false,
@@ -87,36 +150,53 @@ switch{
 }
 
 dynamic_tile{
+  name = "enemy_1",
   layer = 1,
   x = 144,
   y = 136,
+  pattern = "placeholder.enemy",
   width = 32,
   height = 32,
-  name = "enemy_1",
-  pattern = "placeholder.enemy",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "treasure_obstacle_chest",
   layer = 1,
   x = 120,
   y = 136,
+  pattern = "placeholder.treasure_puzzle",
   width = 16,
   height = 16,
-  name = "treasure_obstacle_chest",
-  pattern = "placeholder.treasure_puzzle",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "treasure_open_chest",
   layer = 1,
   x = 120,
   y = 168,
+  pattern = "placeholder.treasure_open",
   width = 16,
   height = 16,
-  name = "treasure_open_chest",
-  pattern = "placeholder.treasure_open",
   enabled_at_start = true,
 }
 
+tile{
+  layer = 2,
+  x = 0,
+  y = 232,
+  width = 184,
+  height = 8,
+  pattern = "ceiling",
+}
+
+tile{
+  layer = 2,
+  x = 0,
+  y = 136,
+  width = 8,
+  height = 96,
+  pattern = "ceiling",
+}
 

--- a/data/maps/components/obstacle_puzzle/obstacle_puzzle_nsew_000007_2.dat
+++ b/data/maps/components/obstacle_puzzle/obstacle_puzzle_nsew_000007_2.dat
@@ -11,6 +11,114 @@ properties{
 
 tile{
   layer = 1,
+  x = 24,
+  y = 136,
+  width = 272,
+  height = 80,
+  pattern = "placeholder.floor.high",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 144,
+  width = 8,
+  height = 64,
+  pattern = "wall_border.high.w",
+}
+
+tile{
+  layer = 1,
+  x = 280,
+  y = 144,
+  width = 8,
+  height = 64,
+  pattern = "wall_border.high.e",
+}
+
+tile{
+  layer = 1,
+  x = 8,
+  y = 208,
+  width = 24,
+  height = 24,
+  pattern = "high_wall_inner_corner.sw",
+}
+
+tile{
+  layer = 1,
+  x = 288,
+  y = 208,
+  width = 24,
+  height = 24,
+  pattern = "high_wall_inner_corner.se",
+}
+
+tile{
+  layer = 1,
+  x = 8,
+  y = 144,
+  width = 24,
+  height = 64,
+  pattern = "high_wall.w",
+}
+
+tile{
+  layer = 1,
+  x = 288,
+  y = 144,
+  width = 24,
+  height = 64,
+  pattern = "high_wall.e",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 208,
+  width = 96,
+  height = 24,
+  pattern = "high_wall.s",
+}
+
+tile{
+  layer = 1,
+  x = 192,
+  y = 208,
+  width = 96,
+  height = 24,
+  pattern = "high_wall.s",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 200,
+  width = 256,
+  height = 8,
+  pattern = "wall_border.high.s",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 200,
+  width = 8,
+  height = 8,
+  pattern = "wall_border_inner_corner.high.sw",
+}
+
+tile{
+  layer = 1,
+  x = 280,
+  y = 200,
+  width = 8,
+  height = 8,
+  pattern = "wall_border_inner_corner.high.se",
+}
+
+tile{
+  layer = 1,
   x = 56,
   y = 152,
   width = 208,
@@ -194,5 +302,32 @@ dynamic_tile{
   width = 16,
   height = 16,
   enabled_at_start = true,
+}
+
+tile{
+  layer = 2,
+  x = 0,
+  y = 232,
+  width = 320,
+  height = 8,
+  pattern = "ceiling",
+}
+
+tile{
+  layer = 2,
+  x = 0,
+  y = 136,
+  width = 8,
+  height = 96,
+  pattern = "ceiling",
+}
+
+tile{
+  layer = 2,
+  x = 312,
+  y = 136,
+  width = 8,
+  height = 96,
+  pattern = "ceiling",
 }
 

--- a/data/maps/components/obstacle_puzzle/obstacle_puzzle_nsew_000007_3.dat
+++ b/data/maps/components/obstacle_puzzle/obstacle_puzzle_nsew_000007_3.dat
@@ -9,45 +9,152 @@ properties{
   music = "same",
 }
 
+tile{
+  layer = 1,
+  x = 24,
+  y = 136,
+  width = 272,
+  height = 80,
+  pattern = "placeholder.floor.high",
+}
+
+tile{
+  layer = 1,
+  x = 8,
+  y = 208,
+  width = 24,
+  height = 24,
+  pattern = "high_wall_inner_corner.sw",
+}
+
+tile{
+  layer = 1,
+  x = 288,
+  y = 208,
+  width = 24,
+  height = 24,
+  pattern = "high_wall_inner_corner.se",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 208,
+  width = 96,
+  height = 24,
+  pattern = "high_wall.s",
+}
+
+tile{
+  layer = 1,
+  x = 192,
+  y = 208,
+  width = 96,
+  height = 24,
+  pattern = "high_wall.s",
+}
+
+tile{
+  layer = 1,
+  x = 8,
+  y = 144,
+  width = 24,
+  height = 64,
+  pattern = "high_wall.w",
+}
+
+tile{
+  layer = 1,
+  x = 288,
+  y = 144,
+  width = 24,
+  height = 64,
+  pattern = "high_wall.e",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 200,
+  width = 256,
+  height = 8,
+  pattern = "wall_border.high.s",
+}
+
+tile{
+  layer = 1,
+  x = 280,
+  y = 144,
+  width = 8,
+  height = 64,
+  pattern = "wall_border.high.e",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 144,
+  width = 8,
+  height = 64,
+  pattern = "wall_border.high.w",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 200,
+  width = 8,
+  height = 8,
+  pattern = "wall_border_inner_corner.high.sw",
+}
+
+tile{
+  layer = 1,
+  x = 280,
+  y = 200,
+  width = 8,
+  height = 8,
+  pattern = "wall_border_inner_corner.high.se",
+}
+
 dynamic_tile{
+  name = "pot_4",
   layer = 1,
   x = 216,
   y = 168,
+  pattern = "placeholder.pot",
   width = 16,
   height = 16,
-  name = "pot_4",
-  pattern = "placeholder.pot",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "pot_2",
   layer = 1,
   x = 232,
   y = 168,
+  pattern = "placeholder.pot",
   width = 16,
   height = 16,
-  name = "pot_2",
-  pattern = "placeholder.pot",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "pot_3",
   layer = 1,
   x = 248,
   y = 168,
+  pattern = "placeholder.pot",
   width = 16,
   height = 16,
-  name = "pot_3",
-  pattern = "placeholder.pot",
   enabled_at_start = true,
 }
 
 block{
+  name = "block_4",
   layer = 1,
   x = 224,
   y = 165,
-  name = "block_4",
-  direction = -1,
   sprite = "entities/block",
   pushable = true,
   pullable = false,
@@ -55,11 +162,10 @@ block{
 }
 
 block{
+  name = "block_2",
   layer = 1,
   x = 240,
   y = 165,
-  name = "block_2",
-  direction = -1,
   sprite = "entities/block",
   pushable = true,
   pullable = false,
@@ -67,11 +173,10 @@ block{
 }
 
 block{
+  name = "block_3",
   layer = 1,
   x = 256,
   y = 165,
-  name = "block_3",
-  direction = -1,
   sprite = "entities/block",
   pushable = true,
   pullable = false,
@@ -79,10 +184,10 @@ block{
 }
 
 switch{
+  name = "switch",
   layer = 1,
   x = 0,
   y = 0,
-  name = "switch",
   subtype = "walkable",
   sprite = "entities/switch",
   needs_block = false,
@@ -98,70 +203,95 @@ enemy{
 }
 
 dynamic_tile{
+  name = "enemy_1",
   layer = 1,
   x = 184,
   y = 152,
+  pattern = "placeholder.enemy",
   width = 32,
   height = 32,
-  name = "enemy_1",
-  pattern = "placeholder.enemy",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "treasure_obstacle_chest",
   layer = 1,
   x = 152,
   y = 152,
+  pattern = "placeholder.treasure_puzzle",
   width = 16,
   height = 16,
-  name = "treasure_obstacle_chest",
-  pattern = "placeholder.treasure_puzzle",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "treasure_open_chest",
   layer = 1,
   x = 168,
   y = 152,
+  pattern = "placeholder.treasure_open",
   width = 16,
   height = 16,
-  name = "treasure_open_chest",
-  pattern = "placeholder.treasure_open",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "enemy_2",
   layer = 1,
   x = 56,
   y = 152,
+  pattern = "placeholder.enemy",
   width = 32,
   height = 32,
-  name = "enemy_2",
-  pattern = "placeholder.enemy",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "pot_5",
   layer = 1,
   x = 264,
   y = 168,
+  pattern = "placeholder.pot",
   width = 16,
   height = 16,
-  name = "pot_5",
-  pattern = "placeholder.pot",
   enabled_at_start = true,
 }
 
 block{
+  name = "block_5",
   layer = 1,
   x = 272,
   y = 165,
-  name = "block_5",
-  direction = -1,
   sprite = "entities/block",
   pushable = true,
   pullable = false,
   maximum_moves = 1,
 }
 
+tile{
+  layer = 2,
+  x = 0,
+  y = 232,
+  width = 320,
+  height = 8,
+  pattern = "ceiling",
+}
+
+tile{
+  layer = 2,
+  x = 312,
+  y = 136,
+  width = 8,
+  height = 96,
+  pattern = "ceiling",
+}
+
+tile{
+  layer = 2,
+  x = 0,
+  y = 136,
+  width = 8,
+  height = 96,
+  pattern = "ceiling",
+}
 

--- a/data/maps/components/obstacle_puzzle/obstacle_puzzle_nsew_000007_4.dat
+++ b/data/maps/components/obstacle_puzzle/obstacle_puzzle_nsew_000007_4.dat
@@ -9,6 +9,114 @@ properties{
   music = "same",
 }
 
+tile{
+  layer = 1,
+  x = 24,
+  y = 136,
+  width = 272,
+  height = 80,
+  pattern = "placeholder.floor.high",
+}
+
+tile{
+  layer = 1,
+  x = 8,
+  y = 208,
+  width = 24,
+  height = 24,
+  pattern = "high_wall_inner_corner.sw",
+}
+
+tile{
+  layer = 1,
+  x = 288,
+  y = 208,
+  width = 24,
+  height = 24,
+  pattern = "high_wall_inner_corner.se",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 208,
+  width = 96,
+  height = 24,
+  pattern = "high_wall.s",
+}
+
+tile{
+  layer = 1,
+  x = 192,
+  y = 208,
+  width = 96,
+  height = 24,
+  pattern = "high_wall.s",
+}
+
+tile{
+  layer = 1,
+  x = 8,
+  y = 144,
+  width = 24,
+  height = 64,
+  pattern = "high_wall.w",
+}
+
+tile{
+  layer = 1,
+  x = 288,
+  y = 144,
+  width = 24,
+  height = 64,
+  pattern = "high_wall.e",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 200,
+  width = 256,
+  height = 8,
+  pattern = "wall_border.high.s",
+}
+
+tile{
+  layer = 1,
+  x = 280,
+  y = 144,
+  width = 8,
+  height = 64,
+  pattern = "wall_border.high.e",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 144,
+  width = 8,
+  height = 64,
+  pattern = "wall_border.high.w",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 200,
+  width = 8,
+  height = 8,
+  pattern = "wall_border_inner_corner.high.sw",
+}
+
+tile{
+  layer = 1,
+  x = 280,
+  y = 200,
+  width = 8,
+  height = 8,
+  pattern = "wall_border_inner_corner.high.se",
+}
+
 dynamic_tile{
   name = "pot_5",
   layer = 1,
@@ -160,4 +268,30 @@ block{
   maximum_moves = 1,
 }
 
+tile{
+  layer = 2,
+  x = 0,
+  y = 232,
+  width = 320,
+  height = 8,
+  pattern = "ceiling",
+}
+
+tile{
+  layer = 2,
+  x = 312,
+  y = 136,
+  width = 8,
+  height = 96,
+  pattern = "ceiling",
+}
+
+tile{
+  layer = 2,
+  x = 0,
+  y = 136,
+  width = 8,
+  height = 96,
+  pattern = "ceiling",
+}
 

--- a/data/maps/components/obstacle_puzzle/obstacle_puzzle_nsew_000300_1.dat
+++ b/data/maps/components/obstacle_puzzle/obstacle_puzzle_nsew_000300_1.dat
@@ -11,6 +11,15 @@ properties{
 
 tile{
   layer = 1,
+  x = 136,
+  y = 24,
+  width = 160,
+  height = 80,
+  pattern = "placeholder.floor.high",
+}
+
+tile{
+  layer = 1,
   x = 232,
   y = 72,
   width = 16,
@@ -18,55 +27,109 @@ tile{
   pattern = "small_statue.1",
 }
 
+tile{
+  layer = 1,
+  x = 288,
+  y = 8,
+  width = 24,
+  height = 24,
+  pattern = "high_wall_inner_corner.ne",
+}
+
+tile{
+  layer = 1,
+  x = 288,
+  y = 32,
+  width = 24,
+  height = 64,
+  pattern = "high_wall.e",
+}
+
+tile{
+  layer = 1,
+  x = 192,
+  y = 8,
+  width = 96,
+  height = 24,
+  pattern = "high_wall.n",
+}
+
+tile{
+  layer = 1,
+  x = 192,
+  y = 32,
+  width = 96,
+  height = 8,
+  pattern = "wall_border.high.n",
+}
+
+tile{
+  layer = 1,
+  x = 280,
+  y = 32,
+  width = 8,
+  height = 64,
+  pattern = "wall_border.high.e",
+}
+
+tile{
+  layer = 1,
+  x = 280,
+  y = 32,
+  width = 8,
+  height = 8,
+  pattern = "wall_border_inner_corner.high.ne",
+}
+
 dynamic_tile{
+  name = "pot_7",
   layer = 1,
   x = 216,
   y = 72,
+  pattern = "placeholder.pot",
   width = 16,
   height = 16,
-  name = "pot_7",
-  pattern = "placeholder.pot",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "pot_3",
   layer = 1,
   x = 248,
   y = 72,
+  pattern = "placeholder.pot",
   width = 16,
   height = 16,
-  name = "pot_3",
-  pattern = "placeholder.pot",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "pot_5",
   layer = 1,
   x = 232,
   y = 88,
+  pattern = "placeholder.pot",
   width = 16,
   height = 16,
-  name = "pot_5",
-  pattern = "placeholder.pot",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "pot_6",
   layer = 1,
   x = 232,
   y = 56,
+  pattern = "placeholder.pot",
   width = 16,
   height = 16,
-  name = "pot_6",
-  pattern = "placeholder.pot",
   enabled_at_start = true,
 }
 
 switch{
+  name = "switch",
   layer = 1,
   x = 0,
   y = 0,
-  name = "switch",
   subtype = "walkable",
   sprite = "entities/switch",
   needs_block = false,
@@ -74,36 +137,53 @@ switch{
 }
 
 dynamic_tile{
+  name = "enemy_1",
   layer = 1,
   x = 176,
   y = 32,
+  pattern = "placeholder.enemy",
   width = 32,
   height = 32,
-  name = "enemy_1",
-  pattern = "placeholder.enemy",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "treasure_obstacle_chest",
   layer = 1,
   x = 152,
   y = 72,
+  pattern = "placeholder.treasure_puzzle",
   width = 16,
   height = 16,
-  name = "treasure_obstacle_chest",
-  pattern = "placeholder.treasure_puzzle",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "treasure_open_chest",
   layer = 1,
   x = 184,
   y = 72,
+  pattern = "placeholder.treasure_open",
   width = 16,
   height = 16,
-  name = "treasure_open_chest",
-  pattern = "placeholder.treasure_open",
   enabled_at_start = true,
 }
 
+tile{
+  layer = 2,
+  x = 136,
+  y = 0,
+  width = 184,
+  height = 8,
+  pattern = "ceiling",
+}
+
+tile{
+  layer = 2,
+  x = 312,
+  y = 8,
+  width = 8,
+  height = 96,
+  pattern = "ceiling",
+}
 

--- a/data/maps/components/obstacle_puzzle/obstacle_puzzle_nsew_000333_1.dat
+++ b/data/maps/components/obstacle_puzzle/obstacle_puzzle_nsew_000333_1.dat
@@ -11,6 +11,78 @@ properties{
 
 tile{
   layer = 1,
+  x = 136,
+  y = 24,
+  width = 160,
+  height = 192,
+  pattern = "placeholder.floor.high",
+}
+
+tile{
+  layer = 1,
+  x = 192,
+  y = 8,
+  width = 96,
+  height = 24,
+  pattern = "high_wall.n",
+}
+
+tile{
+  layer = 1,
+  x = 288,
+  y = 64,
+  width = 24,
+  height = 32,
+  pattern = "high_wall.e",
+}
+
+tile{
+  layer = 1,
+  x = 288,
+  y = 144,
+  width = 24,
+  height = 32,
+  pattern = "high_wall.e",
+}
+
+tile{
+  layer = 1,
+  x = 192,
+  y = 208,
+  width = 96,
+  height = 24,
+  pattern = "high_wall.s",
+}
+
+tile{
+  layer = 1,
+  x = 144,
+  y = 32,
+  width = 48,
+  height = 8,
+  pattern = "wall_border.high.n",
+}
+
+tile{
+  layer = 1,
+  x = 144,
+  y = 200,
+  width = 48,
+  height = 8,
+  pattern = "wall_border.high.s",
+}
+
+tile{
+  layer = 1,
+  x = 280,
+  y = 64,
+  width = 8,
+  height = 112,
+  pattern = "wall_border.high.e",
+}
+
+tile{
+  layer = 1,
   x = 184,
   y = 32,
   width = 8,
@@ -244,10 +316,10 @@ tile{
 }
 
 switch{
+  name = "switch",
   layer = 1,
   x = 0,
   y = 0,
-  name = "switch",
   subtype = "walkable",
   sprite = "entities/switch",
   needs_block = false,
@@ -255,77 +327,76 @@ switch{
 }
 
 dynamic_tile{
-  layer = 1,
-  x = 216,
-  y = 136,
-  width = 16,
-  height = 16,
   name = "pot_7",
+  layer = 1,
+  x = 216,
+  y = 136,
   pattern = "placeholder.pot",
+  width = 16,
+  height = 16,
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "pot_2",
   layer = 1,
   x = 248,
   y = 136,
+  pattern = "placeholder.pot",
   width = 16,
   height = 16,
-  name = "pot_2",
-  pattern = "placeholder.pot",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "pot_3",
   layer = 1,
   x = 248,
   y = 88,
+  pattern = "placeholder.pot",
   width = 16,
   height = 16,
-  name = "pot_3",
-  pattern = "placeholder.pot",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "pot_4",
   layer = 1,
   x = 216,
   y = 88,
+  pattern = "placeholder.pot",
   width = 16,
   height = 16,
-  name = "pot_4",
-  pattern = "placeholder.pot",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "pot_5",
   layer = 1,
   x = 152,
   y = 72,
+  pattern = "placeholder.pot",
   width = 16,
   height = 16,
-  name = "pot_5",
-  pattern = "placeholder.pot",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "pot_6",
   layer = 1,
   x = 152,
   y = 152,
+  pattern = "placeholder.pot",
   width = 16,
   height = 16,
-  name = "pot_6",
-  pattern = "placeholder.pot",
   enabled_at_start = true,
 }
 
 block{
+  name = "block_3",
   layer = 1,
   x = 240,
   y = 101,
-  name = "block_3",
-  direction = -1,
   sprite = "entities/block",
   pushable = true,
   pullable = false,
@@ -333,11 +404,10 @@ block{
 }
 
 block{
+  name = "block_2",
   layer = 1,
   x = 240,
   y = 149,
-  name = "block_2",
-  direction = -1,
   sprite = "entities/block",
   pushable = true,
   pullable = false,
@@ -345,58 +415,84 @@ block{
 }
 
 dynamic_tile{
+  name = "treasure_obstacle_chest",
   layer = 1,
   x = 152,
   y = 112,
+  pattern = "placeholder.treasure_puzzle",
   width = 16,
   height = 16,
-  name = "treasure_obstacle_chest",
-  pattern = "placeholder.treasure_puzzle",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "treasure_open_chest",
   layer = 1,
   x = 176,
   y = 112,
+  pattern = "placeholder.treasure_open",
   width = 16,
   height = 16,
-  name = "treasure_open_chest",
-  pattern = "placeholder.treasure_open",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "enemy_4",
   layer = 1,
   x = 224,
   y = 104,
+  pattern = "placeholder.enemy",
   width = 32,
   height = 32,
-  name = "enemy_4",
-  pattern = "placeholder.enemy",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "enemy_2",
   layer = 1,
   x = 168,
   y = 72,
+  pattern = "placeholder.enemy",
   width = 32,
   height = 32,
-  name = "enemy_2",
-  pattern = "placeholder.enemy",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "enemy_3",
   layer = 1,
   x = 168,
   y = 136,
+  pattern = "placeholder.enemy",
   width = 32,
   height = 32,
-  name = "enemy_3",
-  pattern = "placeholder.enemy",
   enabled_at_start = true,
 }
 
+tile{
+  layer = 2,
+  x = 136,
+  y = 0,
+  width = 184,
+  height = 8,
+  pattern = "ceiling",
+}
+
+tile{
+  layer = 2,
+  x = 136,
+  y = 232,
+  width = 184,
+  height = 8,
+  pattern = "ceiling",
+}
+
+tile{
+  layer = 2,
+  x = 312,
+  y = 8,
+  width = 8,
+  height = 224,
+  pattern = "ceiling",
+}
 

--- a/data/maps/components/obstacle_puzzle/obstacle_puzzle_nsew_000400_2.dat
+++ b/data/maps/components/obstacle_puzzle/obstacle_puzzle_nsew_000400_2.dat
@@ -11,6 +11,15 @@ properties{
 
 tile{
   layer = 1,
+  x = 24,
+  y = 24,
+  width = 112,
+  height = 80,
+  pattern = "placeholder.floor.high",
+}
+
+tile{
+  layer = 1,
   x = 72,
   y = 40,
   width = 16,
@@ -18,11 +27,65 @@ tile{
   pattern = "block",
 }
 
-switch{
+tile{
   layer = 1,
-  x = 0,
-  y = 0,
+  x = 8,
+  y = 8,
+  width = 24,
+  height = 24,
+  pattern = "high_wall_inner_corner.nw",
+}
+
+tile{
+  layer = 1,
+  x = 8,
+  y = 32,
+  width = 24,
+  height = 64,
+  pattern = "high_wall.w",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 8,
+  width = 96,
+  height = 24,
+  pattern = "high_wall.n",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 32,
+  width = 96,
+  height = 8,
+  pattern = "wall_border.high.n",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 32,
+  width = 8,
+  height = 64,
+  pattern = "wall_border.high.w",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 32,
+  width = 8,
+  height = 8,
+  pattern = "wall_border_inner_corner.high.nw",
+}
+
+switch{
   name = "switch",
+  layer = 1,
+  x = -8,
+  y = -8,
   subtype = "walkable",
   sprite = "entities/switch",
   needs_block = false,
@@ -30,11 +93,10 @@ switch{
 }
 
 block{
+  name = "block_1",
   layer = 1,
   x = 64,
   y = 85,
-  name = "block_1",
-  direction = -1,
   sprite = "entities/block",
   pushable = true,
   pullable = false,
@@ -42,11 +104,10 @@ block{
 }
 
 block{
+  name = "block_2",
   layer = 1,
   x = 96,
   y = 69,
-  name = "block_2",
-  direction = -1,
   sprite = "entities/block",
   pushable = true,
   pullable = false,
@@ -54,36 +115,53 @@ block{
 }
 
 dynamic_tile{
+  name = "enemy_1",
   layer = 1,
   x = 88,
   y = 72,
+  pattern = "placeholder.enemy",
   width = 32,
   height = 32,
-  name = "enemy_1",
-  pattern = "placeholder.enemy",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "treasure_obstacle_chest",
   layer = 1,
   x = 120,
   y = 56,
+  pattern = "placeholder.treasure_puzzle",
   width = 16,
   height = 16,
-  name = "treasure_obstacle_chest",
-  pattern = "placeholder.treasure_puzzle",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "treasure_open_chest",
   layer = 1,
   x = 120,
   y = 88,
+  pattern = "placeholder.treasure_open",
   width = 16,
   height = 16,
-  name = "treasure_open_chest",
-  pattern = "placeholder.treasure_open",
   enabled_at_start = true,
 }
 
+tile{
+  layer = 2,
+  x = 0,
+  y = 8,
+  width = 8,
+  height = 96,
+  pattern = "ceiling",
+}
+
+tile{
+  layer = 2,
+  x = 0,
+  y = 0,
+  width = 136,
+  height = 8,
+  pattern = "ceiling",
+}
 

--- a/data/maps/components/obstacle_puzzle/obstacle_puzzle_nsew_000666_1.dat
+++ b/data/maps/components/obstacle_puzzle/obstacle_puzzle_nsew_000666_1.dat
@@ -11,6 +11,51 @@ properties{
 
 tile{
   layer = 1,
+  x = 24,
+  y = 24,
+  width = 160,
+  height = 192,
+  pattern = "placeholder.floor.high",
+}
+
+tile{
+  layer = 1,
+  x = 128,
+  y = 32,
+  width = 8,
+  height = 32,
+  pattern = "wall_border.high.w",
+}
+
+tile{
+  layer = 1,
+  x = 128,
+  y = 176,
+  width = 8,
+  height = 32,
+  pattern = "wall_border.high.w",
+}
+
+tile{
+  layer = 1,
+  x = 128,
+  y = 200,
+  width = 48,
+  height = 8,
+  pattern = "wall_border.high.s",
+}
+
+tile{
+  layer = 1,
+  x = 128,
+  y = 32,
+  width = 48,
+  height = 8,
+  pattern = "wall_border.high.n",
+}
+
+tile{
+  layer = 1,
   x = 32,
   y = 168,
   width = 96,
@@ -147,24 +192,6 @@ tile{
 tile{
   layer = 1,
   x = 128,
-  y = 32,
-  width = 8,
-  height = 32,
-  pattern = "wall_border.high.w",
-}
-
-tile{
-  layer = 1,
-  x = 128,
-  y = 176,
-  width = 8,
-  height = 32,
-  pattern = "wall_border.high.w",
-}
-
-tile{
-  layer = 1,
-  x = 128,
   y = 168,
   width = 8,
   height = 8,
@@ -243,11 +270,92 @@ tile{
   pattern = "ceiling",
 }
 
-switch{
+tile{
   layer = 1,
-  x = 0,
-  y = 0,
+  x = 8,
+  y = 64,
+  width = 24,
+  height = 32,
+  pattern = "high_wall.w",
+}
+
+tile{
+  layer = 1,
+  x = 8,
+  y = 144,
+  width = 24,
+  height = 32,
+  pattern = "high_wall.w",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 64,
+  width = 8,
+  height = 112,
+  pattern = "wall_border.high.w",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 64,
+  width = 8,
+  height = 8,
+  pattern = "wall_border_inner_corner.high.nw",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 168,
+  width = 8,
+  height = 8,
+  pattern = "wall_border_inner_corner.high.sw",
+}
+
+tile{
+  layer = 1,
+  x = 128,
+  y = 200,
+  width = 8,
+  height = 8,
+  pattern = "wall_border_inner_corner.high.sw",
+}
+
+tile{
+  layer = 1,
+  x = 128,
+  y = 32,
+  width = 8,
+  height = 8,
+  pattern = "wall_border_inner_corner.high.nw",
+}
+
+tile{
+  layer = 1,
+  x = 128,
+  y = 8,
+  width = 48,
+  height = 24,
+  pattern = "high_wall.n",
+}
+
+tile{
+  layer = 1,
+  x = 128,
+  y = 208,
+  width = 48,
+  height = 24,
+  pattern = "high_wall.s",
+}
+
+switch{
   name = "switch",
+  layer = 1,
+  x = -8,
+  y = -8,
   subtype = "walkable",
   sprite = "entities/switch",
   needs_block = false,
@@ -255,77 +363,76 @@ switch{
 }
 
 dynamic_tile{
-  layer = 1,
-  x = 56,
-  y = 136,
-  width = 16,
-  height = 16,
   name = "pot_8",
+  layer = 1,
+  x = 56,
+  y = 136,
   pattern = "placeholder.pot",
+  width = 16,
+  height = 16,
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "pot_2",
   layer = 1,
   x = 88,
   y = 136,
+  pattern = "placeholder.pot",
   width = 16,
   height = 16,
-  name = "pot_2",
-  pattern = "placeholder.pot",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "pot_3",
   layer = 1,
   x = 88,
   y = 88,
+  pattern = "placeholder.pot",
   width = 16,
   height = 16,
-  name = "pot_3",
-  pattern = "placeholder.pot",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "pot_4",
   layer = 1,
   x = 56,
   y = 88,
+  pattern = "placeholder.pot",
   width = 16,
   height = 16,
-  name = "pot_4",
-  pattern = "placeholder.pot",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "pot_5",
   layer = 1,
   x = 152,
   y = 72,
+  pattern = "placeholder.pot",
   width = 16,
   height = 16,
-  name = "pot_5",
-  pattern = "placeholder.pot",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "pot_6",
   layer = 1,
   x = 152,
   y = 152,
+  pattern = "placeholder.pot",
   width = 16,
   height = 16,
-  name = "pot_6",
-  pattern = "placeholder.pot",
   enabled_at_start = true,
 }
 
 block{
+  name = "block_4",
   layer = 1,
   x = 80,
   y = 101,
-  name = "block_4",
-  direction = -1,
   sprite = "entities/block",
   pushable = true,
   pullable = false,
@@ -333,11 +440,10 @@ block{
 }
 
 block{
+  name = "block_2",
   layer = 1,
   x = 80,
   y = 149,
-  name = "block_2",
-  direction = -1,
   sprite = "entities/block",
   pushable = true,
   pullable = false,
@@ -345,58 +451,84 @@ block{
 }
 
 dynamic_tile{
+  name = "treasure_obstacle_chest",
   layer = 1,
   x = 152,
   y = 112,
+  pattern = "placeholder.treasure_puzzle",
   width = 16,
   height = 16,
-  name = "treasure_obstacle_chest",
-  pattern = "placeholder.treasure_puzzle",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "treasure_open_chest",
   layer = 1,
   x = 128,
   y = 112,
+  pattern = "placeholder.treasure_open",
   width = 16,
   height = 16,
-  name = "treasure_open_chest",
-  pattern = "placeholder.treasure_open",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "enemy_4",
   layer = 1,
   x = 64,
   y = 104,
+  pattern = "placeholder.enemy",
   width = 32,
   height = 32,
-  name = "enemy_4",
-  pattern = "placeholder.enemy",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "enemy_2",
   layer = 1,
   x = 120,
   y = 128,
+  pattern = "placeholder.enemy",
   width = 32,
   height = 32,
-  name = "enemy_2",
-  pattern = "placeholder.enemy",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "enemy_3",
   layer = 1,
   x = 120,
   y = 80,
+  pattern = "placeholder.enemy",
   width = 32,
   height = 32,
-  name = "enemy_3",
-  pattern = "placeholder.enemy",
   enabled_at_start = true,
 }
 
+tile{
+  layer = 2,
+  x = 0,
+  y = 232,
+  width = 184,
+  height = 8,
+  pattern = "ceiling",
+}
+
+tile{
+  layer = 2,
+  x = 0,
+  y = 0,
+  width = 184,
+  height = 8,
+  pattern = "ceiling",
+}
+
+tile{
+  layer = 2,
+  x = 0,
+  y = 8,
+  width = 8,
+  height = 224,
+  pattern = "ceiling",
+}
 

--- a/data/maps/components/obstacle_puzzle/obstacle_puzzle_nsew_000666_1.dat
+++ b/data/maps/components/obstacle_puzzle/obstacle_puzzle_nsew_000666_1.dat
@@ -333,24 +333,6 @@ tile{
   pattern = "wall_border_inner_corner.high.nw",
 }
 
-tile{
-  layer = 1,
-  x = 128,
-  y = 8,
-  width = 48,
-  height = 24,
-  pattern = "high_wall.n",
-}
-
-tile{
-  layer = 1,
-  x = 128,
-  y = 208,
-  width = 48,
-  height = 24,
-  pattern = "high_wall.s",
-}
-
 switch{
   name = "switch",
   layer = 1,

--- a/data/maps/components/obstacle_puzzle/obstacle_puzzle_nsew_000700_2.dat
+++ b/data/maps/components/obstacle_puzzle/obstacle_puzzle_nsew_000700_2.dat
@@ -9,99 +9,207 @@ properties{
   music = "same",
 }
 
+tile{
+  layer = 1,
+  x = 24,
+  y = 24,
+  width = 272,
+  height = 80,
+  pattern = "placeholder.floor.high",
+}
+
+tile{
+  layer = 1,
+  x = 8,
+  y = 8,
+  width = 24,
+  height = 24,
+  pattern = "high_wall_inner_corner.nw",
+}
+
+tile{
+  layer = 1,
+  x = 288,
+  y = 8,
+  width = 24,
+  height = 24,
+  pattern = "high_wall_inner_corner.ne",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 8,
+  width = 96,
+  height = 24,
+  pattern = "high_wall.n",
+}
+
+tile{
+  layer = 1,
+  x = 192,
+  y = 8,
+  width = 96,
+  height = 24,
+  pattern = "high_wall.n",
+}
+
+tile{
+  layer = 1,
+  x = 8,
+  y = 32,
+  width = 24,
+  height = 64,
+  pattern = "high_wall.w",
+}
+
+tile{
+  layer = 1,
+  x = 288,
+  y = 32,
+  width = 24,
+  height = 64,
+  pattern = "high_wall.e",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 32,
+  width = 256,
+  height = 8,
+  pattern = "wall_border.high.n",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 32,
+  width = 8,
+  height = 64,
+  pattern = "wall_border.high.w",
+}
+
+tile{
+  layer = 1,
+  x = 280,
+  y = 32,
+  width = 8,
+  height = 64,
+  pattern = "wall_border.high.e",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 32,
+  width = 8,
+  height = 8,
+  pattern = "wall_border_inner_corner.high.nw",
+}
+
+tile{
+  layer = 1,
+  x = 280,
+  y = 32,
+  width = 8,
+  height = 8,
+  pattern = "wall_border_inner_corner.high.ne",
+}
+
 dynamic_tile{
+  name = "pot_3",
   layer = 1,
   x = 56,
   y = 72,
+  pattern = "placeholder.pot",
   width = 16,
   height = 16,
-  name = "pot_3",
-  pattern = "placeholder.pot",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "pot_1",
   layer = 1,
   x = 56,
   y = 56,
+  pattern = "placeholder.pot",
   width = 16,
   height = 16,
-  name = "pot_1",
-  pattern = "placeholder.pot",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "pot_6",
   layer = 1,
   x = 72,
   y = 56,
+  pattern = "placeholder.pot",
   width = 16,
   height = 16,
-  name = "pot_6",
-  pattern = "placeholder.pot",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "pot_4",
   layer = 1,
   x = 88,
   y = 56,
+  pattern = "placeholder.pot",
   width = 16,
   height = 16,
-  name = "pot_4",
-  pattern = "placeholder.pot",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "pot_2",
   layer = 1,
   x = 248,
   y = 56,
+  pattern = "placeholder.pot",
   width = 16,
   height = 16,
-  name = "pot_2",
-  pattern = "placeholder.pot",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "pot_5",
   layer = 1,
   x = 216,
   y = 56,
+  pattern = "placeholder.pot",
   width = 16,
   height = 16,
-  name = "pot_5",
-  pattern = "placeholder.pot",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "pot_7",
   layer = 1,
   x = 232,
   y = 56,
+  pattern = "placeholder.pot",
   width = 16,
   height = 16,
-  name = "pot_7",
-  pattern = "placeholder.pot",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "pot_8",
   layer = 1,
   x = 248,
   y = 72,
+  pattern = "placeholder.pot",
   width = 16,
   height = 16,
-  name = "pot_8",
-  pattern = "placeholder.pot",
   enabled_at_start = true,
 }
 
 switch{
-  layer = 1,
-  x = 0,
-  y = 0,
   name = "switch",
+  layer = 1,
+  x = -8,
+  y = -8,
   subtype = "walkable",
   sprite = "entities/switch",
   needs_block = false,
@@ -109,36 +217,62 @@ switch{
 }
 
 dynamic_tile{
+  name = "enemy_1",
   layer = 1,
   x = 184,
   y = 56,
+  pattern = "placeholder.enemy",
   width = 32,
   height = 32,
-  name = "enemy_1",
-  pattern = "placeholder.enemy",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "treasure_obstacle_chest",
   layer = 1,
   x = 152,
   y = 56,
+  pattern = "placeholder.treasure_puzzle",
   width = 16,
   height = 16,
-  name = "treasure_obstacle_chest",
-  pattern = "placeholder.treasure_puzzle",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "treasure_open_chest",
   layer = 1,
   x = 120,
   y = 56,
+  pattern = "placeholder.treasure_open",
   width = 16,
   height = 16,
-  name = "treasure_open_chest",
-  pattern = "placeholder.treasure_open",
   enabled_at_start = true,
 }
 
+tile{
+  layer = 2,
+  x = 0,
+  y = 0,
+  width = 320,
+  height = 8,
+  pattern = "ceiling",
+}
+
+tile{
+  layer = 2,
+  x = 0,
+  y = 8,
+  width = 8,
+  height = 96,
+  pattern = "ceiling",
+}
+
+tile{
+  layer = 2,
+  x = 312,
+  y = 8,
+  width = 8,
+  height = 96,
+  pattern = "ceiling",
+}
 

--- a/data/maps/components/obstacle_puzzle/obstacle_puzzle_nsew_000700_4.dat
+++ b/data/maps/components/obstacle_puzzle/obstacle_puzzle_nsew_000700_4.dat
@@ -9,45 +9,152 @@ properties{
   music = "same",
 }
 
+tile{
+  layer = 1,
+  x = 24,
+  y = 24,
+  width = 272,
+  height = 80,
+  pattern = "placeholder.floor.high",
+}
+
+tile{
+  layer = 1,
+  x = 8,
+  y = 8,
+  width = 24,
+  height = 24,
+  pattern = "high_wall_inner_corner.nw",
+}
+
+tile{
+  layer = 1,
+  x = 288,
+  y = 8,
+  width = 24,
+  height = 24,
+  pattern = "high_wall_inner_corner.ne",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 8,
+  width = 96,
+  height = 24,
+  pattern = "high_wall.n",
+}
+
+tile{
+  layer = 1,
+  x = 192,
+  y = 8,
+  width = 96,
+  height = 24,
+  pattern = "high_wall.n",
+}
+
+tile{
+  layer = 1,
+  x = 8,
+  y = 32,
+  width = 24,
+  height = 64,
+  pattern = "high_wall.w",
+}
+
+tile{
+  layer = 1,
+  x = 288,
+  y = 32,
+  width = 24,
+  height = 64,
+  pattern = "high_wall.e",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 32,
+  width = 256,
+  height = 8,
+  pattern = "wall_border.high.n",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 32,
+  width = 8,
+  height = 64,
+  pattern = "wall_border.high.w",
+}
+
+tile{
+  layer = 1,
+  x = 280,
+  y = 32,
+  width = 8,
+  height = 64,
+  pattern = "wall_border.high.e",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 32,
+  width = 8,
+  height = 8,
+  pattern = "wall_border_inner_corner.high.nw",
+}
+
+tile{
+  layer = 1,
+  x = 280,
+  y = 32,
+  width = 8,
+  height = 8,
+  pattern = "wall_border_inner_corner.high.ne",
+}
+
 dynamic_tile{
+  name = "pot_4",
   layer = 1,
   x = 56,
   y = 56,
+  pattern = "placeholder.pot",
   width = 16,
   height = 16,
-  name = "pot_4",
-  pattern = "placeholder.pot",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "pot_2",
   layer = 1,
   x = 72,
   y = 56,
+  pattern = "placeholder.pot",
   width = 16,
   height = 16,
-  name = "pot_2",
-  pattern = "placeholder.pot",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "pot_3",
   layer = 1,
   x = 88,
   y = 56,
+  pattern = "placeholder.pot",
   width = 16,
   height = 16,
-  name = "pot_3",
-  pattern = "placeholder.pot",
   enabled_at_start = true,
 }
 
 block{
+  name = "block_4",
   layer = 1,
   x = 64,
   y = 85,
-  name = "block_4",
-  direction = -1,
   sprite = "entities/block",
   pushable = true,
   pullable = false,
@@ -55,11 +162,10 @@ block{
 }
 
 block{
+  name = "block_2",
   layer = 1,
   x = 80,
   y = 85,
-  name = "block_2",
-  direction = -1,
   sprite = "entities/block",
   pushable = true,
   pullable = false,
@@ -67,11 +173,10 @@ block{
 }
 
 block{
+  name = "block_3",
   layer = 1,
   x = 96,
   y = 85,
-  name = "block_3",
-  direction = -1,
   sprite = "entities/block",
   pushable = true,
   pullable = false,
@@ -87,10 +192,10 @@ enemy{
 }
 
 switch{
-  layer = 1,
-  x = 0,
-  y = 0,
   name = "switch",
+  layer = 1,
+  x = -8,
+  y = -8,
   subtype = "walkable",
   sprite = "entities/switch",
   needs_block = false,
@@ -98,70 +203,95 @@ switch{
 }
 
 dynamic_tile{
+  name = "treasure_obstacle_chest",
   layer = 1,
   x = 152,
   y = 56,
+  pattern = "placeholder.treasure_puzzle",
   width = 16,
   height = 16,
-  name = "treasure_obstacle_chest",
-  pattern = "placeholder.treasure_puzzle",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "treasure_open_chest",
   layer = 1,
   x = 120,
   y = 56,
+  pattern = "placeholder.treasure_open",
   width = 16,
   height = 16,
-  name = "treasure_open_chest",
-  pattern = "placeholder.treasure_open",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "enemy_1",
   layer = 1,
   x = 104,
   y = 72,
+  pattern = "placeholder.enemy",
   width = 32,
   height = 32,
-  name = "enemy_1",
-  pattern = "placeholder.enemy",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "enemy_2",
   layer = 1,
   x = 232,
   y = 56,
+  pattern = "placeholder.enemy",
   width = 32,
   height = 32,
-  name = "enemy_2",
-  pattern = "placeholder.enemy",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "pot_5",
   layer = 1,
   x = 40,
   y = 56,
+  pattern = "placeholder.pot",
   width = 16,
   height = 16,
-  name = "pot_5",
-  pattern = "placeholder.pot",
   enabled_at_start = true,
 }
 
 block{
+  name = "block_5",
   layer = 1,
   x = 48,
   y = 85,
-  name = "block_5",
-  direction = -1,
   sprite = "entities/block",
   pushable = true,
   pullable = false,
   maximum_moves = 1,
 }
 
+tile{
+  layer = 2,
+  x = 0,
+  y = 8,
+  width = 8,
+  height = 96,
+  pattern = "ceiling",
+}
+
+tile{
+  layer = 2,
+  x = 312,
+  y = 8,
+  width = 8,
+  height = 96,
+  pattern = "ceiling",
+}
+
+tile{
+  layer = 2,
+  x = 0,
+  y = 0,
+  width = 320,
+  height = 8,
+  pattern = "ceiling",
+}
 

--- a/data/maps/components/obstacle_puzzle/obstacle_puzzle_nsew_000770_1.dat
+++ b/data/maps/components/obstacle_puzzle/obstacle_puzzle_nsew_000770_1.dat
@@ -11,11 +11,47 @@ properties{
 
 tile{
   layer = 1,
-  x = 256,
-  y = 56,
-  width = 24,
+  x = 24,
+  y = 24,
+  width = 272,
+  height = 112,
+  pattern = "placeholder.floor.high",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 80,
+  width = 8,
+  height = 48,
+  pattern = "wall_border.high.w",
+}
+
+tile{
+  layer = 1,
+  x = 280,
+  y = 80,
+  width = 8,
+  height = 48,
+  pattern = "wall_border.high.e",
+}
+
+tile{
+  layer = 1,
+  x = 64,
+  y = 32,
+  width = 192,
+  height = 8,
+  pattern = "wall_border.high.n",
+}
+
+tile{
+  layer = 1,
+  x = 64,
+  y = 8,
+  width = 192,
   height = 24,
-  pattern = "high_wall_outer_corner.ne",
+  pattern = "high_wall.n",
 }
 
 tile{
@@ -216,11 +252,74 @@ tile{
   pattern = "wall_torch.n",
 }
 
-switch{
+tile{
   layer = 1,
-  x = 0,
-  y = 0,
+  x = 8,
+  y = 80,
+  width = 24,
+  height = 16,
+  pattern = "high_wall.w",
+}
+
+tile{
+  layer = 1,
+  x = 288,
+  y = 80,
+  width = 24,
+  height = 16,
+  pattern = "high_wall.e",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 80,
+  width = 8,
+  height = 8,
+  pattern = "wall_border_inner_corner.high.nw",
+}
+
+tile{
+  layer = 1,
+  x = 280,
+  y = 80,
+  width = 8,
+  height = 8,
+  pattern = "wall_border_inner_corner.high.ne",
+}
+
+tile{
+  layer = 1,
+  x = 64,
+  y = 32,
+  width = 8,
+  height = 8,
+  pattern = "wall_border_inner_corner.high.nw",
+}
+
+tile{
+  layer = 1,
+  x = 248,
+  y = 32,
+  width = 8,
+  height = 8,
+  pattern = "wall_border_inner_corner.high.ne",
+}
+
+tile{
+  layer = 1,
+  x = 256,
+  y = 56,
+  width = 24,
+  height = 24,
+  pattern = "high_wall_outer_corner.ne",
+}
+
+switch{
   name = "switch",
+  layer = 1,
+  x = -8,
+  y = -8,
   subtype = "walkable",
   sprite = "entities/switch",
   needs_block = false,
@@ -228,123 +327,123 @@ switch{
 }
 
 dynamic_tile{
+  name = "treasure_obstacle_chest",
   layer = 1,
   x = 152,
   y = 104,
+  pattern = "placeholder.treasure_puzzle",
   width = 16,
   height = 16,
-  name = "treasure_obstacle_chest",
-  pattern = "placeholder.treasure_puzzle",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "treasure_open_chest",
   layer = 1,
   x = 152,
   y = 72,
+  pattern = "placeholder.treasure_open",
   width = 16,
   height = 16,
-  name = "treasure_open_chest",
-  pattern = "placeholder.treasure_open",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "pot_7",
   layer = 1,
   x = 104,
   y = 72,
+  pattern = "placeholder.pot",
   width = 16,
   height = 16,
-  name = "pot_7",
-  pattern = "placeholder.pot",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "pot_2",
   layer = 1,
   x = 88,
   y = 56,
+  pattern = "placeholder.pot",
   width = 16,
   height = 16,
-  name = "pot_2",
-  pattern = "placeholder.pot",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "pot_3",
   layer = 1,
   x = 120,
   y = 56,
+  pattern = "placeholder.pot",
   width = 16,
   height = 16,
-  name = "pot_3",
-  pattern = "placeholder.pot",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "pot_4",
   layer = 1,
   x = 184,
   y = 56,
+  pattern = "placeholder.pot",
   width = 16,
   height = 16,
-  name = "pot_4",
-  pattern = "placeholder.pot",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "pot_5",
   layer = 1,
   x = 216,
   y = 56,
+  pattern = "placeholder.pot",
   width = 16,
   height = 16,
-  name = "pot_5",
-  pattern = "placeholder.pot",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "pot_6",
   layer = 1,
   x = 200,
   y = 72,
+  pattern = "placeholder.pot",
   width = 16,
   height = 16,
-  name = "pot_6",
-  pattern = "placeholder.pot",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "enemy_1",
   layer = 1,
   x = 72,
   y = 72,
+  pattern = "placeholder.enemy",
   width = 32,
   height = 32,
-  name = "enemy_1",
-  pattern = "placeholder.enemy",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "enemy_2",
   layer = 1,
   x = 216,
   y = 72,
+  pattern = "placeholder.enemy",
   width = 32,
   height = 32,
-  name = "enemy_2",
-  pattern = "placeholder.enemy",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "enemy_3",
   layer = 1,
   x = 120,
   y = 96,
+  pattern = "placeholder.enemy",
   width = 32,
   height = 32,
-  name = "enemy_3",
-  pattern = "placeholder.enemy",
   enabled_at_start = true,
 }
 
@@ -366,4 +465,30 @@ tile{
   pattern = "ceiling",
 }
 
+tile{
+  layer = 2,
+  x = 0,
+  y = 8,
+  width = 8,
+  height = 128,
+  pattern = "ceiling",
+}
+
+tile{
+  layer = 2,
+  x = 0,
+  y = 0,
+  width = 320,
+  height = 8,
+  pattern = "ceiling",
+}
+
+tile{
+  layer = 2,
+  x = 312,
+  y = 8,
+  width = 8,
+  height = 128,
+  pattern = "ceiling",
+}
 

--- a/data/maps/components/obstacle_puzzle/obstacle_puzzle_nsew_000777_1.dat
+++ b/data/maps/components/obstacle_puzzle/obstacle_puzzle_nsew_000777_1.dat
@@ -9,55 +9,244 @@ properties{
   music = "same",
 }
 
-dynamic_tile{
+tile{
   layer = 1,
-  x = 40,
-  y = 40,
-  width = 16,
-  height = 16,
+  x = 24,
+  y = 24,
+  width = 272,
+  height = 192,
+  pattern = "placeholder.floor.high",
+}
+
+tile{
+  layer = 1,
+  x = 8,
+  y = 8,
+  width = 24,
+  height = 24,
+  pattern = "high_wall_inner_corner.nw",
+}
+
+tile{
+  layer = 1,
+  x = 288,
+  y = 8,
+  width = 24,
+  height = 24,
+  pattern = "high_wall_inner_corner.ne",
+}
+
+tile{
+  layer = 1,
+  x = 288,
+  y = 208,
+  width = 24,
+  height = 24,
+  pattern = "high_wall_inner_corner.se",
+}
+
+tile{
+  layer = 1,
+  x = 8,
+  y = 208,
+  width = 24,
+  height = 24,
+  pattern = "high_wall_inner_corner.sw",
+}
+
+tile{
+  layer = 1,
+  x = 8,
+  y = 144,
+  width = 24,
+  height = 64,
+  pattern = "high_wall.w",
+}
+
+tile{
+  layer = 1,
+  x = 8,
+  y = 32,
+  width = 24,
+  height = 64,
+  pattern = "high_wall.w",
+}
+
+tile{
+  layer = 1,
+  x = 288,
+  y = 32,
+  width = 24,
+  height = 64,
+  pattern = "high_wall.e",
+}
+
+tile{
+  layer = 1,
+  x = 288,
+  y = 144,
+  width = 24,
+  height = 64,
+  pattern = "high_wall.e",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 208,
+  width = 96,
+  height = 24,
+  pattern = "high_wall.s",
+}
+
+tile{
+  layer = 1,
+  x = 192,
+  y = 208,
+  width = 96,
+  height = 24,
+  pattern = "high_wall.s",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 8,
+  width = 96,
+  height = 24,
+  pattern = "high_wall.n",
+}
+
+tile{
+  layer = 1,
+  x = 192,
+  y = 8,
+  width = 96,
+  height = 24,
+  pattern = "high_wall.n",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 200,
+  width = 256,
+  height = 8,
+  pattern = "wall_border.high.s",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 32,
+  width = 256,
+  height = 8,
+  pattern = "wall_border.high.n",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 32,
+  width = 8,
+  height = 176,
+  pattern = "wall_border.high.w",
+}
+
+tile{
+  layer = 1,
+  x = 280,
+  y = 32,
+  width = 8,
+  height = 176,
+  pattern = "wall_border.high.e",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 32,
+  width = 8,
+  height = 8,
+  pattern = "wall_border_inner_corner.high.nw",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 200,
+  width = 8,
+  height = 8,
+  pattern = "wall_border_inner_corner.high.sw",
+}
+
+tile{
+  layer = 1,
+  x = 280,
+  y = 200,
+  width = 8,
+  height = 8,
+  pattern = "wall_border_inner_corner.high.se",
+}
+
+tile{
+  layer = 1,
+  x = 280,
+  y = 32,
+  width = 8,
+  height = 8,
+  pattern = "wall_border_inner_corner.high.ne",
+}
+
+dynamic_tile{
   name = "pot_8",
+  layer = 1,
+  x = 40,
+  y = 40,
   pattern = "placeholder.pot",
+  width = 16,
+  height = 16,
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "pot_2",
   layer = 1,
   x = 264,
   y = 40,
+  pattern = "placeholder.pot",
   width = 16,
   height = 16,
-  name = "pot_2",
-  pattern = "placeholder.pot",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "pot_4",
   layer = 1,
   x = 40,
   y = 184,
+  pattern = "placeholder.pot",
   width = 16,
   height = 16,
-  name = "pot_4",
-  pattern = "placeholder.pot",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "pot_5",
   layer = 1,
   x = 264,
   y = 184,
+  pattern = "placeholder.pot",
   width = 16,
   height = 16,
-  name = "pot_5",
-  pattern = "placeholder.pot",
   enabled_at_start = true,
 }
 
 switch{
-  layer = 1,
-  x = 0,
-  y = 0,
   name = "switch",
+  layer = 1,
+  x = -8,
+  y = -8,
   subtype = "walkable",
   sprite = "entities/switch",
   needs_block = false,
@@ -65,11 +254,10 @@ switch{
 }
 
 block{
-  layer = 1,
-  x = 64,
-  y = 181,
   name = "block_3",
-  direction = -1,
+  layer = 1,
+  x = 64,
+  y = 181,
   sprite = "entities/block",
   pushable = true,
   pullable = false,
@@ -77,11 +265,10 @@ block{
 }
 
 block{
+  name = "block_1",
   layer = 1,
   x = 64,
   y = 69,
-  name = "block_1",
-  direction = -1,
   sprite = "entities/block",
   pushable = true,
   pullable = false,
@@ -89,11 +276,10 @@ block{
 }
 
 block{
+  name = "block_2",
   layer = 1,
   x = 256,
   y = 69,
-  name = "block_2",
-  direction = -1,
   sprite = "entities/block",
   pushable = true,
   pullable = false,
@@ -101,11 +287,10 @@ block{
 }
 
 block{
+  name = "block_4",
   layer = 1,
   x = 256,
   y = 181,
-  name = "block_4",
-  direction = -1,
   sprite = "entities/block",
   pushable = true,
   pullable = false,
@@ -113,36 +298,71 @@ block{
 }
 
 dynamic_tile{
+  name = "enemy_1",
   layer = 1,
   x = 184,
   y = 136,
+  pattern = "placeholder.enemy",
   width = 32,
   height = 32,
-  name = "enemy_1",
-  pattern = "placeholder.enemy",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "treasure_obstacle_chest",
   layer = 1,
   x = 152,
   y = 112,
+  pattern = "placeholder.treasure_puzzle",
   width = 16,
   height = 16,
-  name = "treasure_obstacle_chest",
-  pattern = "placeholder.treasure_puzzle",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "treasure_open_chest",
   layer = 1,
   x = 152,
   y = 72,
+  pattern = "placeholder.treasure_open",
   width = 16,
   height = 16,
-  name = "treasure_open_chest",
-  pattern = "placeholder.treasure_open",
   enabled_at_start = true,
 }
 
+tile{
+  layer = 2,
+  x = 0,
+  y = 0,
+  width = 320,
+  height = 8,
+  pattern = "ceiling",
+}
+
+tile{
+  layer = 2,
+  x = 0,
+  y = 232,
+  width = 320,
+  height = 8,
+  pattern = "ceiling",
+}
+
+tile{
+  layer = 2,
+  x = 312,
+  y = 8,
+  width = 8,
+  height = 224,
+  pattern = "ceiling",
+}
+
+tile{
+  layer = 2,
+  x = 0,
+  y = 8,
+  width = 8,
+  height = 224,
+  pattern = "ceiling",
+}
 

--- a/data/maps/components/obstacle_puzzle/obstacle_puzzle_nsew_000777_3.dat
+++ b/data/maps/components/obstacle_puzzle/obstacle_puzzle_nsew_000777_3.dat
@@ -11,6 +11,15 @@ properties{
 
 tile{
   layer = 1,
+  x = 24,
+  y = 24,
+  width = 272,
+  height = 192,
+  pattern = "placeholder.floor.high",
+}
+
+tile{
+  layer = 1,
   x = 136,
   y = 104,
   width = 64,
@@ -81,11 +90,191 @@ tile{
   pattern = "block",
 }
 
-switch{
+tile{
   layer = 1,
-  x = 0,
-  y = 0,
+  x = 8,
+  y = 208,
+  width = 24,
+  height = 24,
+  pattern = "high_wall_inner_corner.sw",
+}
+
+tile{
+  layer = 1,
+  x = 288,
+  y = 208,
+  width = 24,
+  height = 24,
+  pattern = "high_wall_inner_corner.se",
+}
+
+tile{
+  layer = 1,
+  x = 288,
+  y = 8,
+  width = 24,
+  height = 24,
+  pattern = "high_wall_inner_corner.ne",
+}
+
+tile{
+  layer = 1,
+  x = 8,
+  y = 8,
+  width = 24,
+  height = 24,
+  pattern = "high_wall_inner_corner.nw",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 8,
+  width = 96,
+  height = 24,
+  pattern = "high_wall.n",
+}
+
+tile{
+  layer = 1,
+  x = 192,
+  y = 8,
+  width = 96,
+  height = 24,
+  pattern = "high_wall.n",
+}
+
+tile{
+  layer = 1,
+  x = 8,
+  y = 32,
+  width = 24,
+  height = 64,
+  pattern = "high_wall.w",
+}
+
+tile{
+  layer = 1,
+  x = 8,
+  y = 144,
+  width = 24,
+  height = 64,
+  pattern = "high_wall.w",
+}
+
+tile{
+  layer = 1,
+  x = 288,
+  y = 32,
+  width = 24,
+  height = 64,
+  pattern = "high_wall.e",
+}
+
+tile{
+  layer = 1,
+  x = 288,
+  y = 144,
+  width = 24,
+  height = 64,
+  pattern = "high_wall.e",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 208,
+  width = 96,
+  height = 24,
+  pattern = "high_wall.s",
+}
+
+tile{
+  layer = 1,
+  x = 192,
+  y = 208,
+  width = 96,
+  height = 24,
+  pattern = "high_wall.s",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 32,
+  width = 256,
+  height = 8,
+  pattern = "wall_border.high.n",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 200,
+  width = 256,
+  height = 8,
+  pattern = "wall_border.high.s",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 32,
+  width = 8,
+  height = 176,
+  pattern = "wall_border.high.w",
+}
+
+tile{
+  layer = 1,
+  x = 280,
+  y = 32,
+  width = 8,
+  height = 176,
+  pattern = "wall_border.high.e",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 32,
+  width = 8,
+  height = 8,
+  pattern = "wall_border_inner_corner.high.nw",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 200,
+  width = 8,
+  height = 8,
+  pattern = "wall_border_inner_corner.high.sw",
+}
+
+tile{
+  layer = 1,
+  x = 280,
+  y = 200,
+  width = 8,
+  height = 8,
+  pattern = "wall_border_inner_corner.high.se",
+}
+
+tile{
+  layer = 1,
+  x = 280,
+  y = 32,
+  width = 8,
+  height = 8,
+  pattern = "wall_border_inner_corner.high.ne",
+}
+
+switch{
   name = "switch",
+  layer = 1,
+  x = -8,
+  y = -8,
   subtype = "walkable",
   sprite = "entities/switch",
   needs_block = false,
@@ -93,201 +282,236 @@ switch{
 }
 
 dynamic_tile{
-  layer = 1,
-  x = 248,
-  y = 40,
-  width = 16,
-  height = 16,
   name = "pot_5",
+  layer = 1,
+  x = 248,
+  y = 40,
   pattern = "placeholder.pot",
+  width = 16,
+  height = 16,
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "pot_2",
   layer = 1,
   x = 264,
   y = 40,
+  pattern = "placeholder.pot",
   width = 16,
   height = 16,
-  name = "pot_2",
-  pattern = "placeholder.pot",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "pot_3",
   layer = 1,
   x = 248,
   y = 56,
+  pattern = "placeholder.pot",
   width = 16,
   height = 16,
-  name = "pot_3",
-  pattern = "placeholder.pot",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "pot_4",
   layer = 1,
   x = 264,
   y = 56,
+  pattern = "placeholder.pot",
   width = 16,
   height = 16,
-  name = "pot_4",
-  pattern = "placeholder.pot",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "enemy_7",
   layer = 1,
   x = 40,
   y = 136,
+  pattern = "placeholder.enemy",
   width = 32,
   height = 32,
-  name = "enemy_7",
-  pattern = "placeholder.enemy",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "enemy_5",
   layer = 1,
   x = 248,
   y = 136,
+  pattern = "placeholder.enemy",
   width = 32,
   height = 32,
-  name = "enemy_5",
-  pattern = "placeholder.enemy",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "enemy_8",
   layer = 1,
   x = 200,
   y = 40,
+  pattern = "placeholder.enemy",
   width = 32,
   height = 32,
-  name = "enemy_8",
-  pattern = "placeholder.enemy",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "enemy_9",
   layer = 1,
   x = 88,
   y = 40,
+  pattern = "placeholder.enemy",
   width = 32,
   height = 32,
-  name = "enemy_9",
-  pattern = "placeholder.enemy",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "treasure_obstacle_chest",
   layer = 1,
   x = 248,
   y = 72,
-  width = 16,
-  height = 16,
-  name = "treasure_obstacle_chest",
   pattern = "placeholder.treasure_puzzle",
+  width = 16,
+  height = 16,
   enabled_at_start = true,
 }
 
 dynamic_tile{
-  layer = 1,
-  x = 56,
-  y = 40,
-  width = 16,
-  height = 16,
   name = "pot_6",
+  layer = 1,
+  x = 56,
+  y = 40,
   pattern = "placeholder.pot",
+  width = 16,
+  height = 16,
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "pot_7",
   layer = 1,
   x = 40,
   y = 56,
+  pattern = "placeholder.pot",
   width = 16,
   height = 16,
-  name = "pot_7",
-  pattern = "placeholder.pot",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "pot_8",
   layer = 1,
   x = 40,
   y = 40,
+  pattern = "placeholder.pot",
   width = 16,
   height = 16,
-  name = "pot_8",
-  pattern = "placeholder.pot",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "pot_9",
   layer = 1,
   x = 56,
   y = 56,
+  pattern = "placeholder.pot",
   width = 16,
   height = 16,
-  name = "pot_9",
-  pattern = "placeholder.pot",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "pot_10",
   layer = 1,
   x = 40,
   y = 184,
+  pattern = "placeholder.pot",
   width = 16,
   height = 16,
-  name = "pot_10",
-  pattern = "placeholder.pot",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "pot_11",
   layer = 1,
   x = 56,
   y = 184,
+  pattern = "placeholder.pot",
   width = 16,
   height = 16,
-  name = "pot_11",
-  pattern = "placeholder.pot",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "pot_12",
   layer = 1,
   x = 248,
   y = 184,
+  pattern = "placeholder.pot",
   width = 16,
   height = 16,
-  name = "pot_12",
-  pattern = "placeholder.pot",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "pot_13",
   layer = 1,
   x = 264,
   y = 184,
+  pattern = "placeholder.pot",
   width = 16,
   height = 16,
-  name = "pot_13",
-  pattern = "placeholder.pot",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "treasure_open_chest",
   layer = 1,
   x = 56,
   y = 72,
+  pattern = "placeholder.treasure_open",
   width = 16,
   height = 16,
-  name = "treasure_open_chest",
-  pattern = "placeholder.treasure_open",
   enabled_at_start = true,
 }
 
+tile{
+  layer = 2,
+  x = 0,
+  y = 0,
+  width = 320,
+  height = 8,
+  pattern = "ceiling",
+}
+
+tile{
+  layer = 2,
+  x = 0,
+  y = 232,
+  width = 320,
+  height = 8,
+  pattern = "ceiling",
+}
+
+tile{
+  layer = 2,
+  x = 0,
+  y = 8,
+  width = 8,
+  height = 224,
+  pattern = "ceiling",
+}
+
+tile{
+  layer = 2,
+  x = 312,
+  y = 8,
+  width = 8,
+  height = 224,
+  pattern = "ceiling",
+}
 

--- a/data/maps/components/obstacle_puzzle/obstacle_puzzle_nsew_000777_4.dat
+++ b/data/maps/components/obstacle_puzzle/obstacle_puzzle_nsew_000777_4.dat
@@ -11,6 +11,15 @@ properties{
 
 tile{
   layer = 1,
+  x = 24,
+  y = 24,
+  width = 272,
+  height = 192,
+  pattern = "placeholder.floor.high",
+}
+
+tile{
+  layer = 1,
   x = 40,
   y = 40,
   width = 16,
@@ -151,6 +160,186 @@ tile{
   width = 16,
   height = 8,
   pattern = "placeholder.barrier.3",
+}
+
+tile{
+  layer = 1,
+  x = 8,
+  y = 8,
+  width = 24,
+  height = 24,
+  pattern = "high_wall_inner_corner.nw",
+}
+
+tile{
+  layer = 1,
+  x = 288,
+  y = 8,
+  width = 24,
+  height = 24,
+  pattern = "high_wall_inner_corner.ne",
+}
+
+tile{
+  layer = 1,
+  x = 288,
+  y = 208,
+  width = 24,
+  height = 24,
+  pattern = "high_wall_inner_corner.se",
+}
+
+tile{
+  layer = 1,
+  x = 8,
+  y = 208,
+  width = 24,
+  height = 24,
+  pattern = "high_wall_inner_corner.sw",
+}
+
+tile{
+  layer = 1,
+  x = 8,
+  y = 32,
+  width = 24,
+  height = 64,
+  pattern = "high_wall.w",
+}
+
+tile{
+  layer = 1,
+  x = 288,
+  y = 32,
+  width = 24,
+  height = 64,
+  pattern = "high_wall.e",
+}
+
+tile{
+  layer = 1,
+  x = 288,
+  y = 144,
+  width = 24,
+  height = 64,
+  pattern = "high_wall.e",
+}
+
+tile{
+  layer = 1,
+  x = 8,
+  y = 144,
+  width = 24,
+  height = 64,
+  pattern = "high_wall.w",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 208,
+  width = 96,
+  height = 24,
+  pattern = "high_wall.s",
+}
+
+tile{
+  layer = 1,
+  x = 192,
+  y = 208,
+  width = 96,
+  height = 24,
+  pattern = "high_wall.s",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 8,
+  width = 96,
+  height = 24,
+  pattern = "high_wall.n",
+}
+
+tile{
+  layer = 1,
+  x = 192,
+  y = 8,
+  width = 96,
+  height = 24,
+  pattern = "high_wall.n",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 32,
+  width = 256,
+  height = 8,
+  pattern = "wall_border.high.n",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 200,
+  width = 256,
+  height = 8,
+  pattern = "wall_border.high.s",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 32,
+  width = 8,
+  height = 176,
+  pattern = "wall_border.high.w",
+}
+
+tile{
+  layer = 1,
+  x = 280,
+  y = 32,
+  width = 8,
+  height = 176,
+  pattern = "wall_border.high.e",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 200,
+  width = 8,
+  height = 8,
+  pattern = "wall_border_inner_corner.high.sw",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 32,
+  width = 8,
+  height = 8,
+  pattern = "wall_border_inner_corner.high.nw",
+}
+
+tile{
+  layer = 1,
+  x = 280,
+  y = 32,
+  width = 8,
+  height = 8,
+  pattern = "wall_border_inner_corner.high.ne",
+}
+
+tile{
+  layer = 1,
+  x = 280,
+  y = 200,
+  width = 8,
+  height = 8,
+  pattern = "wall_border_inner_corner.high.se",
 }
 
 block{
@@ -220,8 +409,8 @@ block{
 switch{
   name = "switch",
   layer = 1,
-  x = 0,
-  y = 0,
+  x = -8,
+  y = -8,
   subtype = "walkable",
   sprite = "entities/switch",
   needs_block = false,
@@ -358,4 +547,39 @@ block{
   maximum_moves = 1,
 }
 
+tile{
+  layer = 2,
+  x = 0,
+  y = 0,
+  width = 320,
+  height = 8,
+  pattern = "ceiling",
+}
+
+tile{
+  layer = 2,
+  x = 0,
+  y = 232,
+  width = 320,
+  height = 8,
+  pattern = "ceiling",
+}
+
+tile{
+  layer = 2,
+  x = 312,
+  y = 8,
+  width = 8,
+  height = 224,
+  pattern = "ceiling",
+}
+
+tile{
+  layer = 2,
+  x = 0,
+  y = 8,
+  width = 8,
+  height = 224,
+  pattern = "ceiling",
+}
 

--- a/data/maps/components/obstacle_puzzle/obstacle_puzzle_nsew_000777_5.dat
+++ b/data/maps/components/obstacle_puzzle/obstacle_puzzle_nsew_000777_5.dat
@@ -11,6 +11,33 @@ properties{
 
 tile{
   layer = 1,
+  x = 24,
+  y = 24,
+  width = 272,
+  height = 192,
+  pattern = "placeholder.floor.high",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 8,
+  width = 96,
+  height = 24,
+  pattern = "high_wall.n",
+}
+
+tile{
+  layer = 1,
+  x = 192,
+  y = 8,
+  width = 96,
+  height = 24,
+  pattern = "high_wall.n",
+}
+
+tile{
+  layer = 1,
   x = 136,
   y = 168,
   width = 96,
@@ -180,11 +207,173 @@ tile{
   pattern = "block",
 }
 
-switch{
+tile{
   layer = 1,
-  x = 0,
-  y = 0,
+  x = 8,
+  y = 8,
+  width = 24,
+  height = 24,
+  pattern = "high_wall_inner_corner.nw",
+}
+
+tile{
+  layer = 1,
+  x = 288,
+  y = 8,
+  width = 24,
+  height = 24,
+  pattern = "high_wall_inner_corner.ne",
+}
+
+tile{
+  layer = 1,
+  x = 8,
+  y = 208,
+  width = 24,
+  height = 24,
+  pattern = "high_wall_inner_corner.sw",
+}
+
+tile{
+  layer = 1,
+  x = 288,
+  y = 208,
+  width = 24,
+  height = 24,
+  pattern = "high_wall_inner_corner.se",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 208,
+  width = 96,
+  height = 24,
+  pattern = "high_wall.s",
+}
+
+tile{
+  layer = 1,
+  x = 192,
+  y = 208,
+  width = 96,
+  height = 24,
+  pattern = "high_wall.s",
+}
+
+tile{
+  layer = 1,
+  x = 8,
+  y = 32,
+  width = 24,
+  height = 64,
+  pattern = "high_wall.w",
+}
+
+tile{
+  layer = 1,
+  x = 8,
+  y = 144,
+  width = 24,
+  height = 64,
+  pattern = "high_wall.w",
+}
+
+tile{
+  layer = 1,
+  x = 288,
+  y = 32,
+  width = 24,
+  height = 64,
+  pattern = "high_wall.e",
+}
+
+tile{
+  layer = 1,
+  x = 288,
+  y = 144,
+  width = 24,
+  height = 64,
+  pattern = "high_wall.e",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 32,
+  width = 256,
+  height = 8,
+  pattern = "wall_border.high.n",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 200,
+  width = 256,
+  height = 8,
+  pattern = "wall_border.high.s",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 32,
+  width = 8,
+  height = 176,
+  pattern = "wall_border.high.w",
+}
+
+tile{
+  layer = 1,
+  x = 280,
+  y = 32,
+  width = 8,
+  height = 176,
+  pattern = "wall_border.high.e",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 32,
+  width = 8,
+  height = 8,
+  pattern = "wall_border_inner_corner.high.nw",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 200,
+  width = 8,
+  height = 8,
+  pattern = "wall_border_inner_corner.high.sw",
+}
+
+tile{
+  layer = 1,
+  x = 280,
+  y = 200,
+  width = 8,
+  height = 8,
+  pattern = "wall_border_inner_corner.high.se",
+}
+
+tile{
+  layer = 1,
+  x = 280,
+  y = 32,
+  width = 8,
+  height = 8,
+  pattern = "wall_border_inner_corner.high.ne",
+}
+
+switch{
   name = "switch",
+  layer = 1,
+  x = -8,
+  y = -8,
   subtype = "walkable",
   sprite = "entities/switch",
   needs_block = false,
@@ -192,179 +381,214 @@ switch{
 }
 
 dynamic_tile{
+  name = "treasure_obstacle_chest",
   layer = 1,
   x = 152,
   y = 56,
+  pattern = "placeholder.treasure_puzzle",
   width = 16,
   height = 16,
-  name = "treasure_obstacle_chest",
-  pattern = "placeholder.treasure_puzzle",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "enemy_7",
   layer = 1,
   x = 176,
   y = 48,
+  pattern = "placeholder.enemy",
   width = 32,
   height = 32,
-  name = "enemy_7",
-  pattern = "placeholder.enemy",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "enemy_3",
   layer = 1,
   x = 240,
   y = 80,
+  pattern = "placeholder.enemy",
   width = 32,
   height = 32,
-  name = "enemy_3",
-  pattern = "placeholder.enemy",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "pot_1",
   layer = 1,
   x = 264,
   y = 40,
+  pattern = "placeholder.pot",
   width = 16,
   height = 16,
-  name = "pot_1",
-  pattern = "placeholder.pot",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "pot_3",
   layer = 1,
   x = 232,
   y = 40,
+  pattern = "placeholder.pot",
   width = 16,
   height = 16,
-  name = "pot_3",
-  pattern = "placeholder.pot",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "pot_2",
   layer = 1,
   x = 248,
   y = 40,
+  pattern = "placeholder.pot",
   width = 16,
   height = 16,
-  name = "pot_2",
-  pattern = "placeholder.pot",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "pot_4",
   layer = 1,
   x = 40,
   y = 184,
+  pattern = "placeholder.pot",
   width = 16,
   height = 16,
-  name = "pot_4",
-  pattern = "placeholder.pot",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "pot_5",
   layer = 1,
   x = 56,
   y = 184,
+  pattern = "placeholder.pot",
   width = 16,
   height = 16,
-  name = "pot_5",
-  pattern = "placeholder.pot",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "pot_6",
   layer = 1,
   x = 72,
   y = 184,
+  pattern = "placeholder.pot",
   width = 16,
   height = 16,
-  name = "pot_6",
-  pattern = "placeholder.pot",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "pot_7",
   layer = 1,
   x = 56,
   y = 40,
+  pattern = "placeholder.pot",
   width = 16,
   height = 16,
-  name = "pot_7",
-  pattern = "placeholder.pot",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "pot_8",
   layer = 1,
   x = 40,
   y = 40,
+  pattern = "placeholder.pot",
   width = 16,
   height = 16,
-  name = "pot_8",
-  pattern = "placeholder.pot",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "pot_9",
   layer = 1,
   x = 40,
   y = 56,
+  pattern = "placeholder.pot",
   width = 16,
   height = 16,
-  name = "pot_9",
-  pattern = "placeholder.pot",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "pot_10",
   layer = 1,
   x = 264,
   y = 152,
+  pattern = "placeholder.pot",
   width = 16,
   height = 16,
-  name = "pot_10",
-  pattern = "placeholder.pot",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "pot_11",
   layer = 1,
   x = 264,
   y = 168,
+  pattern = "placeholder.pot",
   width = 16,
   height = 16,
-  name = "pot_11",
-  pattern = "placeholder.pot",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "pot_12",
   layer = 1,
   x = 56,
   y = 56,
+  pattern = "placeholder.pot",
   width = 16,
   height = 16,
-  name = "pot_12",
-  pattern = "placeholder.pot",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "treasure_open_chest",
   layer = 1,
   x = 72,
   y = 56,
+  pattern = "placeholder.treasure_open",
   width = 16,
   height = 16,
-  name = "treasure_open_chest",
-  pattern = "placeholder.treasure_open",
   enabled_at_start = true,
 }
 
+tile{
+  layer = 2,
+  x = 0,
+  y = 0,
+  width = 320,
+  height = 8,
+  pattern = "ceiling",
+}
+
+tile{
+  layer = 2,
+  x = 0,
+  y = 232,
+  width = 320,
+  height = 8,
+  pattern = "ceiling",
+}
+
+tile{
+  layer = 2,
+  x = 0,
+  y = 8,
+  width = 8,
+  height = 224,
+  pattern = "ceiling",
+}
+
+tile{
+  layer = 2,
+  x = 312,
+  y = 8,
+  width = 8,
+  height = 224,
+  pattern = "ceiling",
+}
 

--- a/data/maps/components/obstacle_veryweakwall/obstacle_veryweakwall_e_000111_1.dat
+++ b/data/maps/components/obstacle_veryweakwall/obstacle_veryweakwall_e_000111_1.dat
@@ -11,9 +11,9 @@ properties{
 
 tile{
   layer = 1,
-  x = 184,
+  x = 200,
   y = 24,
-  width = 112,
+  width = 96,
   height = 192,
   pattern = "placeholder.floor.high",
 }
@@ -29,9 +29,9 @@ tile{
 
 tile{
   layer = 1,
-  x = 192,
+  x = 208,
   y = 8,
-  width = 96,
+  width = 80,
   height = 24,
   pattern = "high_wall.n",
 }
@@ -47,9 +47,9 @@ tile{
 
 tile{
   layer = 1,
-  x = 192,
+  x = 208,
   y = 32,
-  width = 96,
+  width = 80,
   height = 8,
   pattern = "wall_border.high.n",
 }
@@ -92,18 +92,18 @@ tile{
 
 tile{
   layer = 1,
-  x = 192,
+  x = 208,
   y = 208,
-  width = 96,
+  width = 80,
   height = 24,
   pattern = "high_wall.s",
 }
 
 tile{
   layer = 1,
-  x = 192,
+  x = 208,
   y = 200,
-  width = 96,
+  width = 80,
   height = 8,
   pattern = "wall_border.high.s",
 }
@@ -184,9 +184,9 @@ dynamic_tile{
 
 tile{
   layer = 2,
-  x = 184,
+  x = 192,
   y = 0,
-  width = 136,
+  width = 128,
   height = 8,
   pattern = "ceiling",
 }
@@ -202,9 +202,9 @@ tile{
 
 tile{
   layer = 2,
-  x = 184,
+  x = 192,
   y = 232,
-  width = 136,
+  width = 128,
   height = 8,
   pattern = "ceiling",
 }

--- a/data/maps/components/obstacle_veryweakwall/obstacle_veryweakwall_e_000111_1.dat
+++ b/data/maps/components/obstacle_veryweakwall/obstacle_veryweakwall_e_000111_1.dat
@@ -9,69 +9,203 @@ properties{
   music = "same",
 }
 
+tile{
+  layer = 1,
+  x = 184,
+  y = 24,
+  width = 112,
+  height = 192,
+  pattern = "placeholder.floor.high",
+}
+
+tile{
+  layer = 1,
+  x = 288,
+  y = 8,
+  width = 24,
+  height = 24,
+  pattern = "high_wall_inner_corner.ne",
+}
+
+tile{
+  layer = 1,
+  x = 192,
+  y = 8,
+  width = 96,
+  height = 24,
+  pattern = "high_wall.n",
+}
+
+tile{
+  layer = 1,
+  x = 288,
+  y = 32,
+  width = 24,
+  height = 64,
+  pattern = "high_wall.e",
+}
+
+tile{
+  layer = 1,
+  x = 192,
+  y = 32,
+  width = 96,
+  height = 8,
+  pattern = "wall_border.high.n",
+}
+
+tile{
+  layer = 1,
+  x = 280,
+  y = 32,
+  width = 8,
+  height = 176,
+  pattern = "wall_border.high.e",
+}
+
+tile{
+  layer = 1,
+  x = 280,
+  y = 32,
+  width = 8,
+  height = 8,
+  pattern = "wall_border_inner_corner.high.ne",
+}
+
+tile{
+  layer = 1,
+  x = 288,
+  y = 208,
+  width = 24,
+  height = 24,
+  pattern = "high_wall_inner_corner.se",
+}
+
+tile{
+  layer = 1,
+  x = 288,
+  y = 144,
+  width = 24,
+  height = 64,
+  pattern = "high_wall.e",
+}
+
+tile{
+  layer = 1,
+  x = 192,
+  y = 208,
+  width = 96,
+  height = 24,
+  pattern = "high_wall.s",
+}
+
+tile{
+  layer = 1,
+  x = 192,
+  y = 200,
+  width = 96,
+  height = 8,
+  pattern = "wall_border.high.s",
+}
+
+tile{
+  layer = 1,
+  x = 280,
+  y = 200,
+  width = 8,
+  height = 8,
+  pattern = "wall_border_inner_corner.high.se",
+}
+
 dynamic_tile{
+  name = "treasure_obstacle_carpet",
   layer = 1,
   x = 208,
   y = 48,
+  pattern = "carpet.1",
   width = 32,
   height = 48,
-  name = "treasure_obstacle_carpet",
-  pattern = "carpet.1",
   enabled_at_start = true,
 }
 
 door{
+  name = "treasure_obstacle_block",
   layer = 1,
   x = 216,
   y = 72,
-  name = "treasure_obstacle_block",
   direction = 1,
   sprite = "entities/door_weak_block",
   opening_method = "explosion",
 }
 
 dynamic_tile{
+  name = "treasure_open_carpet",
   layer = 1,
   x = 240,
   y = 48,
+  pattern = "carpet.1",
   width = 32,
   height = 48,
-  name = "treasure_open_carpet",
-  pattern = "carpet.1",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "enemy_1",
   layer = 1,
   x = 240,
   y = 72,
+  pattern = "placeholder.enemy",
   width = 32,
   height = 32,
-  name = "enemy_1",
-  pattern = "placeholder.enemy",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "treasure_open_chest",
   layer = 1,
   x = 248,
   y = 56,
+  pattern = "placeholder.treasure_open",
   width = 16,
   height = 16,
-  name = "treasure_open_chest",
-  pattern = "placeholder.treasure_open",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "treasure_obstacle_chest",
   layer = 1,
   x = 216,
   y = 56,
+  pattern = "placeholder.treasure_obstacle",
   width = 16,
   height = 16,
-  name = "treasure_obstacle_chest",
-  pattern = "placeholder.treasure_obstacle",
   enabled_at_start = true,
 }
 
+tile{
+  layer = 2,
+  x = 184,
+  y = 0,
+  width = 136,
+  height = 8,
+  pattern = "ceiling",
+}
+
+tile{
+  layer = 2,
+  x = 312,
+  y = 8,
+  width = 8,
+  height = 224,
+  pattern = "ceiling",
+}
+
+tile{
+  layer = 2,
+  x = 184,
+  y = 232,
+  width = 136,
+  height = 8,
+  pattern = "ceiling",
+}
 

--- a/data/maps/components/obstacle_veryweakwall/obstacle_veryweakwall_n_000700_1.dat
+++ b/data/maps/components/obstacle_veryweakwall/obstacle_veryweakwall_n_000700_1.dat
@@ -9,69 +9,203 @@ properties{
   music = "same",
 }
 
+tile{
+  layer = 1,
+  x = 24,
+  y = 24,
+  width = 272,
+  height = 80,
+  pattern = "placeholder.floor.high",
+}
+
+tile{
+  layer = 1,
+  x = 288,
+  y = 8,
+  width = 24,
+  height = 24,
+  pattern = "high_wall_inner_corner.ne",
+}
+
+tile{
+  layer = 1,
+  x = 192,
+  y = 8,
+  width = 96,
+  height = 24,
+  pattern = "high_wall.n",
+}
+
+tile{
+  layer = 1,
+  x = 288,
+  y = 32,
+  width = 24,
+  height = 64,
+  pattern = "high_wall.e",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 32,
+  width = 256,
+  height = 8,
+  pattern = "wall_border.high.n",
+}
+
+tile{
+  layer = 1,
+  x = 280,
+  y = 32,
+  width = 8,
+  height = 64,
+  pattern = "wall_border.high.e",
+}
+
+tile{
+  layer = 1,
+  x = 280,
+  y = 32,
+  width = 8,
+  height = 8,
+  pattern = "wall_border_inner_corner.high.ne",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 8,
+  width = 96,
+  height = 24,
+  pattern = "high_wall.n",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 32,
+  width = 8,
+  height = 64,
+  pattern = "wall_border.high.w",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 32,
+  width = 8,
+  height = 8,
+  pattern = "wall_border_inner_corner.high.nw",
+}
+
+tile{
+  layer = 1,
+  x = 8,
+  y = 8,
+  width = 24,
+  height = 24,
+  pattern = "high_wall_inner_corner.nw",
+}
+
+tile{
+  layer = 1,
+  x = 8,
+  y = 32,
+  width = 24,
+  height = 64,
+  pattern = "high_wall.w",
+}
+
 dynamic_tile{
+  name = "treasure_obstacle_carpet",
   layer = 1,
   x = 48,
   y = 48,
+  pattern = "carpet.1",
   width = 32,
   height = 48,
-  name = "treasure_obstacle_carpet",
-  pattern = "carpet.1",
   enabled_at_start = true,
 }
 
 door{
+  name = "treasure_obstacle_block",
   layer = 1,
   x = 56,
   y = 72,
-  name = "treasure_obstacle_block",
   direction = 1,
   sprite = "entities/door_weak_block",
   opening_method = "explosion",
 }
 
 dynamic_tile{
+  name = "treasure_open_carpet",
   layer = 1,
   x = 80,
   y = 48,
+  pattern = "carpet.1",
   width = 32,
   height = 48,
-  name = "treasure_open_carpet",
-  pattern = "carpet.1",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "enemy_1",
   layer = 1,
   x = 80,
   y = 72,
+  pattern = "placeholder.enemy",
   width = 32,
   height = 32,
-  name = "enemy_1",
-  pattern = "placeholder.enemy",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "treasure_open_chest",
   layer = 1,
   x = 88,
   y = 56,
+  pattern = "placeholder.treasure_open",
   width = 16,
   height = 16,
-  name = "treasure_open_chest",
-  pattern = "placeholder.treasure_open",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "treasure_obstacle_chest",
   layer = 1,
   x = 56,
   y = 56,
+  pattern = "placeholder.treasure_obstacle",
   width = 16,
   height = 16,
-  name = "treasure_obstacle_chest",
-  pattern = "placeholder.treasure_obstacle",
   enabled_at_start = true,
 }
 
+tile{
+  layer = 2,
+  x = 0,
+  y = 0,
+  width = 320,
+  height = 8,
+  pattern = "ceiling",
+}
+
+tile{
+  layer = 2,
+  x = 312,
+  y = 8,
+  width = 8,
+  height = 96,
+  pattern = "ceiling",
+}
+
+tile{
+  layer = 2,
+  x = 0,
+  y = 8,
+  width = 8,
+  height = 96,
+  pattern = "ceiling",
+}
 

--- a/data/maps/components/obstacle_veryweakwall/obstacle_veryweakwall_ne_000700_1.dat
+++ b/data/maps/components/obstacle_veryweakwall/obstacle_veryweakwall_ne_000700_1.dat
@@ -9,69 +9,203 @@ properties{
   music = "same",
 }
 
+tile{
+  layer = 1,
+  x = 24,
+  y = 24,
+  width = 272,
+  height = 80,
+  pattern = "placeholder.floor.high",
+}
+
+tile{
+  layer = 1,
+  x = 8,
+  y = 8,
+  width = 24,
+  height = 24,
+  pattern = "high_wall_inner_corner.nw",
+}
+
+tile{
+  layer = 1,
+  x = 8,
+  y = 32,
+  width = 24,
+  height = 64,
+  pattern = "high_wall.w",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 8,
+  width = 96,
+  height = 24,
+  pattern = "high_wall.n",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 32,
+  width = 256,
+  height = 8,
+  pattern = "wall_border.high.n",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 32,
+  width = 8,
+  height = 64,
+  pattern = "wall_border.high.w",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 32,
+  width = 8,
+  height = 8,
+  pattern = "wall_border_inner_corner.high.nw",
+}
+
+tile{
+  layer = 1,
+  x = 288,
+  y = 8,
+  width = 24,
+  height = 24,
+  pattern = "high_wall_inner_corner.ne",
+}
+
+tile{
+  layer = 1,
+  x = 280,
+  y = 32,
+  width = 8,
+  height = 64,
+  pattern = "wall_border.high.e",
+}
+
+tile{
+  layer = 1,
+  x = 280,
+  y = 32,
+  width = 8,
+  height = 8,
+  pattern = "wall_border_inner_corner.high.ne",
+}
+
+tile{
+  layer = 1,
+  x = 288,
+  y = 32,
+  width = 24,
+  height = 64,
+  pattern = "high_wall.e",
+}
+
+tile{
+  layer = 1,
+  x = 192,
+  y = 8,
+  width = 96,
+  height = 24,
+  pattern = "high_wall.n",
+}
+
 dynamic_tile{
+  name = "treasure_obstacle_carpet",
   layer = 1,
   x = 48,
   y = 48,
+  pattern = "carpet.1",
   width = 32,
   height = 48,
-  name = "treasure_obstacle_carpet",
-  pattern = "carpet.1",
   enabled_at_start = true,
 }
 
 door{
+  name = "treasure_obstacle_block",
   layer = 1,
   x = 56,
   y = 72,
-  name = "treasure_obstacle_block",
   direction = 1,
   sprite = "entities/door_weak_block",
   opening_method = "explosion",
 }
 
 dynamic_tile{
+  name = "treasure_open_carpet",
   layer = 1,
   x = 80,
   y = 48,
+  pattern = "carpet.1",
   width = 32,
   height = 48,
-  name = "treasure_open_carpet",
-  pattern = "carpet.1",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "enemy_1",
   layer = 1,
   x = 80,
   y = 72,
+  pattern = "placeholder.enemy",
   width = 32,
   height = 32,
-  name = "enemy_1",
-  pattern = "placeholder.enemy",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "treasure_open_chest",
   layer = 1,
   x = 88,
   y = 56,
+  pattern = "placeholder.treasure_open",
   width = 16,
   height = 16,
-  name = "treasure_open_chest",
-  pattern = "placeholder.treasure_open",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "treasure_obstacle_chest",
   layer = 1,
   x = 56,
   y = 56,
+  pattern = "placeholder.treasure_obstacle",
   width = 16,
   height = 16,
-  name = "treasure_obstacle_chest",
-  pattern = "placeholder.treasure_obstacle",
   enabled_at_start = true,
 }
 
+tile{
+  layer = 2,
+  x = 0,
+  y = 8,
+  width = 8,
+  height = 96,
+  pattern = "ceiling",
+}
+
+tile{
+  layer = 2,
+  x = 0,
+  y = 0,
+  width = 320,
+  height = 8,
+  pattern = "ceiling",
+}
+
+tile{
+  layer = 2,
+  x = 312,
+  y = 8,
+  width = 8,
+  height = 96,
+  pattern = "ceiling",
+}
 

--- a/data/maps/components/obstacle_veryweakwall/obstacle_veryweakwall_new_000700_1.dat
+++ b/data/maps/components/obstacle_veryweakwall/obstacle_veryweakwall_new_000700_1.dat
@@ -14,7 +14,7 @@ tile{
   x = 24,
   y = 24,
   width = 272,
-  height = 96,
+  height = 80,
   pattern = "placeholder.floor.high",
 }
 
@@ -32,7 +32,7 @@ tile{
   x = 8,
   y = 32,
   width = 24,
-  height = 80,
+  height = 64,
   pattern = "high_wall.w",
 }
 
@@ -59,7 +59,7 @@ tile{
   x = 32,
   y = 32,
   width = 8,
-  height = 80,
+  height = 64,
   pattern = "wall_border.high.w",
 }
 
@@ -86,7 +86,7 @@ tile{
   x = 280,
   y = 32,
   width = 8,
-  height = 80,
+  height = 64,
   pattern = "wall_border.high.e",
 }
 
@@ -104,7 +104,7 @@ tile{
   x = 288,
   y = 32,
   width = 24,
-  height = 80,
+  height = 64,
   pattern = "high_wall.e",
 }
 
@@ -187,7 +187,7 @@ tile{
   x = 0,
   y = 8,
   width = 8,
-  height = 112,
+  height = 96,
   pattern = "ceiling",
 }
 
@@ -205,7 +205,7 @@ tile{
   x = 312,
   y = 8,
   width = 8,
-  height = 112,
+  height = 96,
   pattern = "ceiling",
 }
 

--- a/data/maps/components/obstacle_veryweakwall/obstacle_veryweakwall_new_000700_1.dat
+++ b/data/maps/components/obstacle_veryweakwall/obstacle_veryweakwall_new_000700_1.dat
@@ -9,69 +9,203 @@ properties{
   music = "same",
 }
 
+tile{
+  layer = 1,
+  x = 24,
+  y = 24,
+  width = 272,
+  height = 96,
+  pattern = "placeholder.floor.high",
+}
+
+tile{
+  layer = 1,
+  x = 8,
+  y = 8,
+  width = 24,
+  height = 24,
+  pattern = "high_wall_inner_corner.nw",
+}
+
+tile{
+  layer = 1,
+  x = 8,
+  y = 32,
+  width = 24,
+  height = 80,
+  pattern = "high_wall.w",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 8,
+  width = 96,
+  height = 24,
+  pattern = "high_wall.n",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 32,
+  width = 256,
+  height = 8,
+  pattern = "wall_border.high.n",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 32,
+  width = 8,
+  height = 80,
+  pattern = "wall_border.high.w",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 32,
+  width = 8,
+  height = 8,
+  pattern = "wall_border_inner_corner.high.nw",
+}
+
+tile{
+  layer = 1,
+  x = 288,
+  y = 8,
+  width = 24,
+  height = 24,
+  pattern = "high_wall_inner_corner.ne",
+}
+
+tile{
+  layer = 1,
+  x = 280,
+  y = 32,
+  width = 8,
+  height = 80,
+  pattern = "wall_border.high.e",
+}
+
+tile{
+  layer = 1,
+  x = 280,
+  y = 32,
+  width = 8,
+  height = 8,
+  pattern = "wall_border_inner_corner.high.ne",
+}
+
+tile{
+  layer = 1,
+  x = 288,
+  y = 32,
+  width = 24,
+  height = 80,
+  pattern = "high_wall.e",
+}
+
+tile{
+  layer = 1,
+  x = 192,
+  y = 8,
+  width = 96,
+  height = 24,
+  pattern = "high_wall.n",
+}
+
 dynamic_tile{
+  name = "treasure_obstacle_carpet",
   layer = 1,
   x = 48,
   y = 48,
+  pattern = "carpet.1",
   width = 32,
   height = 48,
-  name = "treasure_obstacle_carpet",
-  pattern = "carpet.1",
   enabled_at_start = true,
 }
 
 door{
+  name = "treasure_obstacle_block",
   layer = 1,
   x = 56,
   y = 72,
-  name = "treasure_obstacle_block",
   direction = 1,
   sprite = "entities/door_weak_block",
   opening_method = "explosion",
 }
 
 dynamic_tile{
+  name = "treasure_open_carpet",
   layer = 1,
   x = 80,
   y = 48,
+  pattern = "carpet.1",
   width = 32,
   height = 48,
-  name = "treasure_open_carpet",
-  pattern = "carpet.1",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "enemy_1",
   layer = 1,
   x = 80,
   y = 72,
+  pattern = "placeholder.enemy",
   width = 32,
   height = 32,
-  name = "enemy_1",
-  pattern = "placeholder.enemy",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "treasure_open_chest",
   layer = 1,
   x = 88,
   y = 56,
+  pattern = "placeholder.treasure_open",
   width = 16,
   height = 16,
-  name = "treasure_open_chest",
-  pattern = "placeholder.treasure_open",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "treasure_obstacle_chest",
   layer = 1,
   x = 56,
   y = 56,
+  pattern = "placeholder.treasure_obstacle",
   width = 16,
   height = 16,
-  name = "treasure_obstacle_chest",
-  pattern = "placeholder.treasure_obstacle",
   enabled_at_start = true,
 }
 
+tile{
+  layer = 2,
+  x = 0,
+  y = 8,
+  width = 8,
+  height = 112,
+  pattern = "ceiling",
+}
+
+tile{
+  layer = 2,
+  x = 0,
+  y = 0,
+  width = 320,
+  height = 8,
+  pattern = "ceiling",
+}
+
+tile{
+  layer = 2,
+  x = 312,
+  y = 8,
+  width = 8,
+  height = 112,
+  pattern = "ceiling",
+}
 

--- a/data/maps/components/obstacle_veryweakwall/obstacle_veryweakwall_nw_000700_1.dat
+++ b/data/maps/components/obstacle_veryweakwall/obstacle_veryweakwall_nw_000700_1.dat
@@ -9,69 +9,203 @@ properties{
   music = "same",
 }
 
+tile{
+  layer = 1,
+  x = 24,
+  y = 24,
+  width = 272,
+  height = 80,
+  pattern = "placeholder.floor.high",
+}
+
+tile{
+  layer = 1,
+  x = 8,
+  y = 8,
+  width = 24,
+  height = 24,
+  pattern = "high_wall_inner_corner.nw",
+}
+
+tile{
+  layer = 1,
+  x = 8,
+  y = 32,
+  width = 24,
+  height = 64,
+  pattern = "high_wall.w",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 8,
+  width = 96,
+  height = 24,
+  pattern = "high_wall.n",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 32,
+  width = 256,
+  height = 8,
+  pattern = "wall_border.high.n",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 32,
+  width = 8,
+  height = 64,
+  pattern = "wall_border.high.w",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 32,
+  width = 8,
+  height = 8,
+  pattern = "wall_border_inner_corner.high.nw",
+}
+
+tile{
+  layer = 1,
+  x = 288,
+  y = 8,
+  width = 24,
+  height = 24,
+  pattern = "high_wall_inner_corner.ne",
+}
+
+tile{
+  layer = 1,
+  x = 280,
+  y = 32,
+  width = 8,
+  height = 64,
+  pattern = "wall_border.high.e",
+}
+
+tile{
+  layer = 1,
+  x = 280,
+  y = 32,
+  width = 8,
+  height = 8,
+  pattern = "wall_border_inner_corner.high.ne",
+}
+
+tile{
+  layer = 1,
+  x = 288,
+  y = 32,
+  width = 24,
+  height = 64,
+  pattern = "high_wall.e",
+}
+
+tile{
+  layer = 1,
+  x = 192,
+  y = 8,
+  width = 96,
+  height = 24,
+  pattern = "high_wall.n",
+}
+
 dynamic_tile{
+  name = "treasure_obstacle_carpet",
   layer = 1,
   x = 48,
   y = 48,
+  pattern = "carpet.1",
   width = 32,
   height = 48,
-  name = "treasure_obstacle_carpet",
-  pattern = "carpet.1",
   enabled_at_start = true,
 }
 
 door{
+  name = "treasure_obstacle_block",
   layer = 1,
   x = 56,
   y = 72,
-  name = "treasure_obstacle_block",
   direction = 1,
   sprite = "entities/door_weak_block",
   opening_method = "explosion",
 }
 
 dynamic_tile{
+  name = "treasure_open_carpet",
   layer = 1,
   x = 80,
   y = 48,
+  pattern = "carpet.1",
   width = 32,
   height = 48,
-  name = "treasure_open_carpet",
-  pattern = "carpet.1",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "enemy_1",
   layer = 1,
   x = 80,
   y = 72,
+  pattern = "placeholder.enemy",
   width = 32,
   height = 32,
-  name = "enemy_1",
-  pattern = "placeholder.enemy",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "treasure_open_chest",
   layer = 1,
   x = 88,
   y = 56,
+  pattern = "placeholder.treasure_open",
   width = 16,
   height = 16,
-  name = "treasure_open_chest",
-  pattern = "placeholder.treasure_open",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "treasure_obstacle_chest",
   layer = 1,
   x = 56,
   y = 56,
+  pattern = "placeholder.treasure_obstacle",
   width = 16,
   height = 16,
-  name = "treasure_obstacle_chest",
-  pattern = "placeholder.treasure_obstacle",
   enabled_at_start = true,
 }
 
+tile{
+  layer = 2,
+  x = 0,
+  y = 8,
+  width = 8,
+  height = 96,
+  pattern = "ceiling",
+}
+
+tile{
+  layer = 2,
+  x = 0,
+  y = 0,
+  width = 320,
+  height = 8,
+  pattern = "ceiling",
+}
+
+tile{
+  layer = 2,
+  x = 312,
+  y = 8,
+  width = 8,
+  height = 96,
+  pattern = "ceiling",
+}
 

--- a/data/maps/components/obstacle_veryweakwall/obstacle_veryweakwall_s_000007_1.dat
+++ b/data/maps/components/obstacle_veryweakwall/obstacle_veryweakwall_s_000007_1.dat
@@ -12,9 +12,9 @@ properties{
 tile{
   layer = 1,
   x = 24,
-  y = 120,
+  y = 136,
   width = 272,
-  height = 96,
+  height = 80,
   pattern = "placeholder.floor.high",
 }
 
@@ -30,9 +30,9 @@ tile{
 tile{
   layer = 1,
   x = 8,
-  y = 128,
+  y = 144,
   width = 24,
-  height = 80,
+  height = 64,
   pattern = "high_wall.w",
 }
 
@@ -48,9 +48,9 @@ tile{
 tile{
   layer = 1,
   x = 32,
-  y = 128,
+  y = 144,
   width = 8,
-  height = 80,
+  height = 64,
   pattern = "wall_border.high.w",
 }
 
@@ -84,9 +84,9 @@ tile{
 tile{
   layer = 1,
   x = 280,
-  y = 128,
+  y = 144,
   width = 8,
-  height = 80,
+  height = 64,
   pattern = "wall_border.high.e",
 }
 
@@ -111,9 +111,9 @@ tile{
 tile{
   layer = 1,
   x = 288,
-  y = 128,
+  y = 144,
   width = 24,
-  height = 80,
+  height = 64,
   pattern = "high_wall.e",
 }
 
@@ -194,18 +194,18 @@ tile{
 tile{
   layer = 2,
   x = 0,
-  y = 120,
+  y = 136,
   width = 8,
-  height = 112,
+  height = 96,
   pattern = "ceiling",
 }
 
 tile{
   layer = 2,
   x = 312,
-  y = 120,
+  y = 136,
   width = 8,
-  height = 112,
+  height = 96,
   pattern = "ceiling",
 }
 

--- a/data/maps/components/obstacle_veryweakwall/obstacle_veryweakwall_s_000007_1.dat
+++ b/data/maps/components/obstacle_veryweakwall/obstacle_veryweakwall_s_000007_1.dat
@@ -9,69 +9,203 @@ properties{
   music = "same",
 }
 
+tile{
+  layer = 1,
+  x = 24,
+  y = 120,
+  width = 272,
+  height = 96,
+  pattern = "placeholder.floor.high",
+}
+
+tile{
+  layer = 1,
+  x = 8,
+  y = 208,
+  width = 24,
+  height = 24,
+  pattern = "high_wall_inner_corner.sw",
+}
+
+tile{
+  layer = 1,
+  x = 8,
+  y = 128,
+  width = 24,
+  height = 80,
+  pattern = "high_wall.w",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 208,
+  width = 96,
+  height = 24,
+  pattern = "high_wall.s",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 128,
+  width = 8,
+  height = 80,
+  pattern = "wall_border.high.w",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 200,
+  width = 256,
+  height = 8,
+  pattern = "wall_border.high.s",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 200,
+  width = 8,
+  height = 8,
+  pattern = "wall_border_inner_corner.high.sw",
+}
+
+tile{
+  layer = 1,
+  x = 192,
+  y = 208,
+  width = 96,
+  height = 24,
+  pattern = "high_wall.s",
+}
+
+tile{
+  layer = 1,
+  x = 280,
+  y = 128,
+  width = 8,
+  height = 80,
+  pattern = "wall_border.high.e",
+}
+
+tile{
+  layer = 1,
+  x = 280,
+  y = 200,
+  width = 8,
+  height = 8,
+  pattern = "wall_border_inner_corner.high.se",
+}
+
+tile{
+  layer = 1,
+  x = 288,
+  y = 208,
+  width = 24,
+  height = 24,
+  pattern = "high_wall_inner_corner.se",
+}
+
+tile{
+  layer = 1,
+  x = 288,
+  y = 128,
+  width = 24,
+  height = 80,
+  pattern = "high_wall.e",
+}
+
 dynamic_tile{
+  name = "treasure_obstacle_carpet",
   layer = 1,
   x = 48,
   y = 144,
+  pattern = "carpet.1",
   width = 32,
   height = 48,
-  name = "treasure_obstacle_carpet",
-  pattern = "carpet.1",
   enabled_at_start = true,
 }
 
 door{
+  name = "treasure_obstacle_block",
   layer = 1,
   x = 56,
   y = 168,
-  name = "treasure_obstacle_block",
   direction = 1,
   sprite = "entities/door_weak_block",
   opening_method = "explosion",
 }
 
 dynamic_tile{
+  name = "treasure_open_carpet",
   layer = 1,
   x = 80,
   y = 144,
+  pattern = "carpet.1",
   width = 32,
   height = 48,
-  name = "treasure_open_carpet",
-  pattern = "carpet.1",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "enemy_1",
   layer = 1,
   x = 80,
   y = 168,
+  pattern = "placeholder.enemy",
   width = 32,
   height = 32,
-  name = "enemy_1",
-  pattern = "placeholder.enemy",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "treasure_open_chest",
   layer = 1,
   x = 88,
   y = 152,
+  pattern = "placeholder.treasure_open",
   width = 16,
   height = 16,
-  name = "treasure_open_chest",
-  pattern = "placeholder.treasure_open",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "treasure_obstacle_chest",
   layer = 1,
   x = 56,
   y = 152,
+  pattern = "placeholder.treasure_obstacle",
   width = 16,
   height = 16,
-  name = "treasure_obstacle_chest",
-  pattern = "placeholder.treasure_obstacle",
   enabled_at_start = true,
 }
 
+tile{
+  layer = 2,
+  x = 0,
+  y = 232,
+  width = 320,
+  height = 8,
+  pattern = "ceiling",
+}
+
+tile{
+  layer = 2,
+  x = 0,
+  y = 120,
+  width = 8,
+  height = 112,
+  pattern = "ceiling",
+}
+
+tile{
+  layer = 2,
+  x = 312,
+  y = 120,
+  width = 8,
+  height = 112,
+  pattern = "ceiling",
+}
 

--- a/data/maps/components/obstacle_veryweakwall/obstacle_veryweakwall_w_000444_1.dat
+++ b/data/maps/components/obstacle_veryweakwall/obstacle_veryweakwall_w_000444_1.dat
@@ -9,69 +9,203 @@ properties{
   music = "same",
 }
 
+tile{
+  layer = 1,
+  x = 24,
+  y = 24,
+  width = 112,
+  height = 192,
+  pattern = "placeholder.floor.high",
+}
+
+tile{
+  layer = 1,
+  x = 8,
+  y = 208,
+  width = 24,
+  height = 24,
+  pattern = "high_wall_inner_corner.sw",
+}
+
+tile{
+  layer = 1,
+  x = 8,
+  y = 144,
+  width = 24,
+  height = 64,
+  pattern = "high_wall.w",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 208,
+  width = 96,
+  height = 24,
+  pattern = "high_wall.s",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 32,
+  width = 8,
+  height = 176,
+  pattern = "wall_border.high.w",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 200,
+  width = 96,
+  height = 8,
+  pattern = "wall_border.high.s",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 200,
+  width = 8,
+  height = 8,
+  pattern = "wall_border_inner_corner.high.sw",
+}
+
+tile{
+  layer = 1,
+  x = 8,
+  y = 32,
+  width = 24,
+  height = 64,
+  pattern = "high_wall.w",
+}
+
+tile{
+  layer = 1,
+  x = 8,
+  y = 8,
+  width = 24,
+  height = 24,
+  pattern = "high_wall_inner_corner.nw",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 8,
+  width = 96,
+  height = 24,
+  pattern = "high_wall.n",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 32,
+  width = 96,
+  height = 8,
+  pattern = "wall_border.high.n",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 32,
+  width = 8,
+  height = 8,
+  pattern = "wall_border_inner_corner.high.nw",
+}
+
 dynamic_tile{
+  name = "treasure_obstacle_carpet",
   layer = 1,
   x = 48,
   y = 56,
+  pattern = "carpet.1",
   width = 32,
   height = 48,
-  name = "treasure_obstacle_carpet",
-  pattern = "carpet.1",
   enabled_at_start = true,
 }
 
 door{
+  name = "treasure_obstacle_block",
   layer = 1,
   x = 56,
   y = 80,
-  name = "treasure_obstacle_block",
   direction = 1,
   sprite = "entities/door_weak_block",
   opening_method = "explosion",
 }
 
 dynamic_tile{
+  name = "treasure_open_carpet",
   layer = 1,
   x = 80,
   y = 56,
+  pattern = "carpet.1",
   width = 32,
   height = 48,
-  name = "treasure_open_carpet",
-  pattern = "carpet.1",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "enemy_1",
   layer = 1,
   x = 80,
   y = 80,
+  pattern = "placeholder.enemy",
   width = 32,
   height = 32,
-  name = "enemy_1",
-  pattern = "placeholder.enemy",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "treasure_open_chest",
   layer = 1,
   x = 88,
   y = 64,
+  pattern = "placeholder.treasure_open",
   width = 16,
   height = 16,
-  name = "treasure_open_chest",
-  pattern = "placeholder.treasure_open",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "treasure_obstacle_chest",
   layer = 1,
   x = 56,
   y = 64,
+  pattern = "placeholder.treasure_obstacle",
   width = 16,
   height = 16,
-  name = "treasure_obstacle_chest",
-  pattern = "placeholder.treasure_obstacle",
   enabled_at_start = true,
 }
 
+tile{
+  layer = 2,
+  x = 0,
+  y = 232,
+  width = 136,
+  height = 8,
+  pattern = "ceiling",
+}
+
+tile{
+  layer = 2,
+  x = 0,
+  y = 8,
+  width = 8,
+  height = 224,
+  pattern = "ceiling",
+}
+
+tile{
+  layer = 2,
+  x = 0,
+  y = 0,
+  width = 136,
+  height = 8,
+  pattern = "ceiling",
+}
 

--- a/data/maps/components/obstacle_weakwall/obstacle_weakwall_e_000100_1.dat
+++ b/data/maps/components/obstacle_weakwall/obstacle_weakwall_e_000100_1.dat
@@ -9,47 +9,127 @@ properties{
   music = "same",
 }
 
+tile{
+  layer = 1,
+  x = 184,
+  y = 24,
+  width = 112,
+  height = 80,
+  pattern = "placeholder.floor.high",
+}
+
+tile{
+  layer = 1,
+  x = 288,
+  y = 8,
+  width = 24,
+  height = 24,
+  pattern = "high_wall_inner_corner.ne",
+}
+
+tile{
+  layer = 1,
+  x = 192,
+  y = 8,
+  width = 96,
+  height = 24,
+  pattern = "high_wall.n",
+}
+
+tile{
+  layer = 1,
+  x = 288,
+  y = 32,
+  width = 24,
+  height = 64,
+  pattern = "high_wall.e",
+}
+
+tile{
+  layer = 1,
+  x = 192,
+  y = 32,
+  width = 96,
+  height = 8,
+  pattern = "wall_border.high.n",
+}
+
+tile{
+  layer = 1,
+  x = 280,
+  y = 32,
+  width = 8,
+  height = 64,
+  pattern = "wall_border.high.e",
+}
+
+tile{
+  layer = 1,
+  x = 280,
+  y = 32,
+  width = 8,
+  height = 8,
+  pattern = "wall_border_inner_corner.high.ne",
+}
+
 door{
+  name = "treasure_obstacle_block",
   layer = 1,
   x = 224,
   y = 64,
-  name = "treasure_obstacle_block",
   direction = 1,
   sprite = "entities/door_weak_block",
   opening_method = "explosion",
 }
 
 dynamic_tile{
+  name = "enemy_1",
   layer = 1,
   x = 184,
   y = 40,
+  pattern = "placeholder.enemy",
   width = 32,
   height = 32,
-  name = "enemy_1",
-  pattern = "placeholder.enemy",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "treasure_open_chest",
   layer = 1,
   x = 256,
   y = 48,
+  pattern = "placeholder.treasure_open",
   width = 16,
   height = 16,
-  name = "treasure_open_chest",
-  pattern = "placeholder.treasure_open",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "treasure_obstacle_chest",
   layer = 1,
   x = 224,
   y = 48,
+  pattern = "placeholder.treasure_obstacle",
   width = 16,
   height = 16,
-  name = "treasure_obstacle_chest",
-  pattern = "placeholder.treasure_obstacle",
   enabled_at_start = true,
 }
 
+tile{
+  layer = 2,
+  x = 184,
+  y = 0,
+  width = 136,
+  height = 8,
+  pattern = "ceiling",
+}
+
+tile{
+  layer = 2,
+  x = 312,
+  y = 8,
+  width = 8,
+  height = 96,
+  pattern = "ceiling",
+}
 

--- a/data/maps/components/obstacle_weakwall/obstacle_weakwall_ew_050400_1.dat
+++ b/data/maps/components/obstacle_weakwall/obstacle_weakwall_ew_050400_1.dat
@@ -14,7 +14,7 @@ tile{
   x = 24,
   y = 24,
   width = 112,
-  height = 96,
+  height = 80,
   pattern = "placeholder.floor.high",
 }
 
@@ -32,7 +32,7 @@ tile{
   x = 8,
   y = 32,
   width = 24,
-  height = 80,
+  height = 64,
   pattern = "high_wall.w",
 }
 
@@ -59,7 +59,7 @@ tile{
   x = 32,
   y = 32,
   width = 8,
-  height = 80,
+  height = 64,
   pattern = "wall_border.high.w",
 }
 
@@ -142,7 +142,7 @@ tile{
   x = 0,
   y = 8,
   width = 8,
-  height = 112,
+  height = 104,
   pattern = "ceiling",
 }
 

--- a/data/maps/components/obstacle_weakwall/obstacle_weakwall_ew_050400_1.dat
+++ b/data/maps/components/obstacle_weakwall/obstacle_weakwall_ew_050400_1.dat
@@ -9,69 +9,149 @@ properties{
   music = "same",
 }
 
+tile{
+  layer = 1,
+  x = 24,
+  y = 24,
+  width = 112,
+  height = 96,
+  pattern = "placeholder.floor.high",
+}
+
+tile{
+  layer = 1,
+  x = 8,
+  y = 8,
+  width = 24,
+  height = 24,
+  pattern = "high_wall_inner_corner.nw",
+}
+
+tile{
+  layer = 1,
+  x = 8,
+  y = 32,
+  width = 24,
+  height = 80,
+  pattern = "high_wall.w",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 8,
+  width = 96,
+  height = 24,
+  pattern = "high_wall.n",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 32,
+  width = 96,
+  height = 8,
+  pattern = "wall_border.high.n",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 32,
+  width = 8,
+  height = 80,
+  pattern = "wall_border.high.w",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 32,
+  width = 8,
+  height = 8,
+  pattern = "wall_border_inner_corner.high.nw",
+}
+
 dynamic_tile{
+  name = "treasure_obstacle_carpet",
   layer = 1,
   x = 48,
   y = 48,
+  pattern = "carpet.1",
   width = 32,
   height = 48,
-  name = "treasure_obstacle_carpet",
-  pattern = "carpet.1",
   enabled_at_start = true,
 }
 
 door{
+  name = "treasure_obstacle_block",
   layer = 1,
   x = 56,
   y = 72,
-  name = "treasure_obstacle_block",
   direction = 1,
   sprite = "entities/door_weak_block",
   opening_method = "explosion",
 }
 
 dynamic_tile{
+  name = "treasure_open_carpet",
   layer = 1,
   x = 80,
   y = 48,
+  pattern = "carpet.1",
   width = 32,
   height = 48,
-  name = "treasure_open_carpet",
-  pattern = "carpet.1",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "enemy_1",
   layer = 1,
   x = 80,
   y = 72,
+  pattern = "placeholder.enemy",
   width = 32,
   height = 32,
-  name = "enemy_1",
-  pattern = "placeholder.enemy",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "treasure_open_chest",
   layer = 1,
   x = 88,
   y = 56,
+  pattern = "placeholder.treasure_open",
   width = 16,
   height = 16,
-  name = "treasure_open_chest",
-  pattern = "placeholder.treasure_open",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "treasure_obstacle_chest",
   layer = 1,
   x = 56,
   y = 56,
+  pattern = "placeholder.treasure_obstacle",
   width = 16,
   height = 16,
-  name = "treasure_obstacle_chest",
-  pattern = "placeholder.treasure_obstacle",
   enabled_at_start = true,
 }
 
+tile{
+  layer = 2,
+  x = 0,
+  y = 8,
+  width = 8,
+  height = 112,
+  pattern = "ceiling",
+}
+
+tile{
+  layer = 2,
+  x = 0,
+  y = 0,
+  width = 136,
+  height = 8,
+  pattern = "ceiling",
+}
 

--- a/data/maps/components/obstacle_weakwall/obstacle_weakwall_n_000400_1.dat
+++ b/data/maps/components/obstacle_weakwall/obstacle_weakwall_n_000400_1.dat
@@ -9,69 +9,149 @@ properties{
   music = "same",
 }
 
+tile{
+  layer = 1,
+  x = 24,
+  y = 24,
+  width = 112,
+  height = 96,
+  pattern = "placeholder.floor.high",
+}
+
+tile{
+  layer = 1,
+  x = 8,
+  y = 8,
+  width = 24,
+  height = 24,
+  pattern = "high_wall_inner_corner.nw",
+}
+
+tile{
+  layer = 1,
+  x = 8,
+  y = 32,
+  width = 24,
+  height = 80,
+  pattern = "high_wall.w",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 8,
+  width = 96,
+  height = 24,
+  pattern = "high_wall.n",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 32,
+  width = 96,
+  height = 8,
+  pattern = "wall_border.high.n",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 32,
+  width = 8,
+  height = 80,
+  pattern = "wall_border.high.w",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 32,
+  width = 8,
+  height = 8,
+  pattern = "wall_border_inner_corner.high.nw",
+}
+
 dynamic_tile{
+  name = "treasure_obstacle_carpet",
   layer = 1,
   x = 48,
   y = 48,
+  pattern = "carpet.1",
   width = 32,
   height = 48,
-  name = "treasure_obstacle_carpet",
-  pattern = "carpet.1",
   enabled_at_start = true,
 }
 
 door{
+  name = "treasure_obstacle_block",
   layer = 1,
   x = 56,
   y = 72,
-  name = "treasure_obstacle_block",
   direction = 1,
   sprite = "entities/door_weak_block",
   opening_method = "explosion",
 }
 
 dynamic_tile{
+  name = "treasure_open_carpet",
   layer = 1,
   x = 80,
   y = 48,
+  pattern = "carpet.1",
   width = 32,
   height = 48,
-  name = "treasure_open_carpet",
-  pattern = "carpet.1",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "enemy_1",
   layer = 1,
   x = 80,
   y = 72,
+  pattern = "placeholder.enemy",
   width = 32,
   height = 32,
-  name = "enemy_1",
-  pattern = "placeholder.enemy",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "treasure_open_chest",
   layer = 1,
   x = 88,
   y = 56,
+  pattern = "placeholder.treasure_open",
   width = 16,
   height = 16,
-  name = "treasure_open_chest",
-  pattern = "placeholder.treasure_open",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "treasure_obstacle_chest",
   layer = 1,
   x = 56,
   y = 56,
+  pattern = "placeholder.treasure_obstacle",
   width = 16,
   height = 16,
-  name = "treasure_obstacle_chest",
-  pattern = "placeholder.treasure_obstacle",
   enabled_at_start = true,
 }
 
+tile{
+  layer = 2,
+  x = 0,
+  y = 8,
+  width = 8,
+  height = 112,
+  pattern = "ceiling",
+}
+
+tile{
+  layer = 2,
+  x = 0,
+  y = 0,
+  width = 136,
+  height = 8,
+  pattern = "ceiling",
+}
 

--- a/data/maps/components/obstacle_weakwall/obstacle_weakwall_n_000400_1.dat
+++ b/data/maps/components/obstacle_weakwall/obstacle_weakwall_n_000400_1.dat
@@ -14,7 +14,7 @@ tile{
   x = 24,
   y = 24,
   width = 112,
-  height = 96,
+  height = 80,
   pattern = "placeholder.floor.high",
 }
 
@@ -32,7 +32,7 @@ tile{
   x = 8,
   y = 32,
   width = 24,
-  height = 80,
+  height = 64,
   pattern = "high_wall.w",
 }
 
@@ -59,7 +59,7 @@ tile{
   x = 32,
   y = 32,
   width = 8,
-  height = 80,
+  height = 64,
   pattern = "wall_border.high.w",
 }
 
@@ -142,7 +142,7 @@ tile{
   x = 0,
   y = 8,
   width = 8,
-  height = 112,
+  height = 96,
   pattern = "ceiling",
 }
 

--- a/data/maps/components/obstacle_weakwall/obstacle_weakwall_ne_210100_1.dat
+++ b/data/maps/components/obstacle_weakwall/obstacle_weakwall_ne_210100_1.dat
@@ -9,47 +9,127 @@ properties{
   music = "same",
 }
 
+tile{
+  layer = 1,
+  x = 184,
+  y = 24,
+  width = 112,
+  height = 80,
+  pattern = "placeholder.floor.high",
+}
+
+tile{
+  layer = 1,
+  x = 288,
+  y = 8,
+  width = 24,
+  height = 24,
+  pattern = "high_wall_inner_corner.ne",
+}
+
+tile{
+  layer = 1,
+  x = 288,
+  y = 32,
+  width = 24,
+  height = 64,
+  pattern = "high_wall.e",
+}
+
+tile{
+  layer = 1,
+  x = 192,
+  y = 8,
+  width = 96,
+  height = 24,
+  pattern = "high_wall.n",
+}
+
+tile{
+  layer = 1,
+  x = 192,
+  y = 32,
+  width = 96,
+  height = 8,
+  pattern = "wall_border.high.n",
+}
+
+tile{
+  layer = 1,
+  x = 280,
+  y = 32,
+  width = 8,
+  height = 64,
+  pattern = "wall_border.high.e",
+}
+
+tile{
+  layer = 1,
+  x = 280,
+  y = 32,
+  width = 8,
+  height = 8,
+  pattern = "wall_border_inner_corner.high.ne",
+}
+
 door{
+  name = "treasure_obstacle_block",
   layer = 1,
   x = 224,
   y = 64,
-  name = "treasure_obstacle_block",
   direction = 1,
   sprite = "entities/door_weak_block",
   opening_method = "explosion",
 }
 
 dynamic_tile{
+  name = "enemy_1",
   layer = 1,
   x = 184,
-  y = 40,
+  y = 48,
+  pattern = "placeholder.enemy",
   width = 32,
   height = 32,
-  name = "enemy_1",
-  pattern = "placeholder.enemy",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "treasure_open_chest",
   layer = 1,
   x = 256,
   y = 48,
+  pattern = "placeholder.treasure_open",
   width = 16,
   height = 16,
-  name = "treasure_open_chest",
-  pattern = "placeholder.treasure_open",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "treasure_obstacle_chest",
   layer = 1,
   x = 224,
   y = 48,
+  pattern = "placeholder.treasure_obstacle",
   width = 16,
   height = 16,
-  name = "treasure_obstacle_chest",
-  pattern = "placeholder.treasure_obstacle",
   enabled_at_start = true,
 }
 
+tile{
+  layer = 2,
+  x = 184,
+  y = 0,
+  width = 136,
+  height = 8,
+  pattern = "ceiling",
+}
+
+tile{
+  layer = 2,
+  x = 312,
+  y = 8,
+  width = 8,
+  height = 96,
+  pattern = "ceiling",
+}
 

--- a/data/maps/components/obstacle_weakwall/obstacle_weakwall_new_250400_1.dat
+++ b/data/maps/components/obstacle_weakwall/obstacle_weakwall_new_250400_1.dat
@@ -9,69 +9,149 @@ properties{
   music = "same",
 }
 
+tile{
+  layer = 1,
+  x = 24,
+  y = 24,
+  width = 112,
+  height = 80,
+  pattern = "placeholder.floor.high",
+}
+
+tile{
+  layer = 1,
+  x = 8,
+  y = 8,
+  width = 24,
+  height = 24,
+  pattern = "high_wall_inner_corner.nw",
+}
+
+tile{
+  layer = 1,
+  x = 8,
+  y = 32,
+  width = 24,
+  height = 64,
+  pattern = "high_wall.w",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 8,
+  width = 96,
+  height = 24,
+  pattern = "high_wall.n",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 32,
+  width = 96,
+  height = 8,
+  pattern = "wall_border.high.n",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 32,
+  width = 8,
+  height = 64,
+  pattern = "wall_border.high.w",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 32,
+  width = 8,
+  height = 8,
+  pattern = "wall_border_inner_corner.high.nw",
+}
+
 dynamic_tile{
+  name = "treasure_obstacle_carpet",
   layer = 1,
   x = 48,
   y = 48,
+  pattern = "carpet.1",
   width = 32,
   height = 48,
-  name = "treasure_obstacle_carpet",
-  pattern = "carpet.1",
   enabled_at_start = true,
 }
 
 door{
+  name = "treasure_obstacle_block",
   layer = 1,
   x = 56,
   y = 72,
-  name = "treasure_obstacle_block",
   direction = 1,
   sprite = "entities/door_weak_block",
   opening_method = "explosion",
 }
 
 dynamic_tile{
+  name = "treasure_open_carpet",
   layer = 1,
   x = 80,
   y = 48,
+  pattern = "carpet.1",
   width = 32,
   height = 48,
-  name = "treasure_open_carpet",
-  pattern = "carpet.1",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "enemy_1",
   layer = 1,
   x = 80,
   y = 72,
+  pattern = "placeholder.enemy",
   width = 32,
   height = 32,
-  name = "enemy_1",
-  pattern = "placeholder.enemy",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "treasure_open_chest",
   layer = 1,
   x = 88,
   y = 56,
+  pattern = "placeholder.treasure_open",
   width = 16,
   height = 16,
-  name = "treasure_open_chest",
-  pattern = "placeholder.treasure_open",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "treasure_obstacle_chest",
   layer = 1,
   x = 56,
   y = 56,
+  pattern = "placeholder.treasure_obstacle",
   width = 16,
   height = 16,
-  name = "treasure_obstacle_chest",
-  pattern = "placeholder.treasure_obstacle",
   enabled_at_start = true,
 }
 
+tile{
+  layer = 2,
+  x = 0,
+  y = 8,
+  width = 8,
+  height = 96,
+  pattern = "ceiling",
+}
+
+tile{
+  layer = 2,
+  x = 0,
+  y = 0,
+  width = 136,
+  height = 8,
+  pattern = "ceiling",
+}
 

--- a/data/maps/components/obstacle_weakwall/obstacle_weakwall_nw_240400_1.dat
+++ b/data/maps/components/obstacle_weakwall/obstacle_weakwall_nw_240400_1.dat
@@ -9,69 +9,149 @@ properties{
   music = "same",
 }
 
+tile{
+  layer = 1,
+  x = 24,
+  y = 24,
+  width = 112,
+  height = 96,
+  pattern = "placeholder.floor.high",
+}
+
+tile{
+  layer = 1,
+  x = 8,
+  y = 8,
+  width = 24,
+  height = 24,
+  pattern = "high_wall_inner_corner.nw",
+}
+
+tile{
+  layer = 1,
+  x = 8,
+  y = 32,
+  width = 24,
+  height = 80,
+  pattern = "high_wall.w",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 8,
+  width = 96,
+  height = 24,
+  pattern = "high_wall.n",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 32,
+  width = 96,
+  height = 8,
+  pattern = "wall_border.high.n",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 32,
+  width = 8,
+  height = 80,
+  pattern = "wall_border.high.w",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 32,
+  width = 8,
+  height = 8,
+  pattern = "wall_border_inner_corner.high.nw",
+}
+
 dynamic_tile{
+  name = "treasure_obstacle_carpet",
   layer = 1,
   x = 48,
   y = 48,
+  pattern = "carpet.1",
   width = 32,
   height = 48,
-  name = "treasure_obstacle_carpet",
-  pattern = "carpet.1",
   enabled_at_start = true,
 }
 
 door{
+  name = "treasure_obstacle_block",
   layer = 1,
   x = 56,
   y = 72,
-  name = "treasure_obstacle_block",
   direction = 1,
   sprite = "entities/door_weak_block",
   opening_method = "explosion",
 }
 
 dynamic_tile{
+  name = "treasure_open_carpet",
   layer = 1,
   x = 80,
   y = 48,
+  pattern = "carpet.1",
   width = 32,
   height = 48,
-  name = "treasure_open_carpet",
-  pattern = "carpet.1",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "enemy_1",
   layer = 1,
   x = 80,
   y = 72,
+  pattern = "placeholder.enemy",
   width = 32,
   height = 32,
-  name = "enemy_1",
-  pattern = "placeholder.enemy",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "treasure_open_chest",
   layer = 1,
   x = 88,
   y = 56,
+  pattern = "placeholder.treasure_open",
   width = 16,
   height = 16,
-  name = "treasure_open_chest",
-  pattern = "placeholder.treasure_open",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "treasure_obstacle_chest",
   layer = 1,
   x = 56,
   y = 56,
+  pattern = "placeholder.treasure_obstacle",
   width = 16,
   height = 16,
-  name = "treasure_obstacle_chest",
-  pattern = "placeholder.treasure_obstacle",
   enabled_at_start = true,
 }
 
+tile{
+  layer = 2,
+  x = 0,
+  y = 8,
+  width = 8,
+  height = 112,
+  pattern = "ceiling",
+}
+
+tile{
+  layer = 2,
+  x = 0,
+  y = 0,
+  width = 136,
+  height = 8,
+  pattern = "ceiling",
+}
 

--- a/data/maps/components/obstacle_weakwall/obstacle_weakwall_nw_240400_1.dat
+++ b/data/maps/components/obstacle_weakwall/obstacle_weakwall_nw_240400_1.dat
@@ -14,7 +14,7 @@ tile{
   x = 24,
   y = 24,
   width = 112,
-  height = 96,
+  height = 80,
   pattern = "placeholder.floor.high",
 }
 
@@ -32,7 +32,7 @@ tile{
   x = 8,
   y = 32,
   width = 24,
-  height = 80,
+  height = 64,
   pattern = "high_wall.w",
 }
 
@@ -59,7 +59,7 @@ tile{
   x = 32,
   y = 32,
   width = 8,
-  height = 80,
+  height = 64,
   pattern = "wall_border.high.w",
 }
 
@@ -142,7 +142,7 @@ tile{
   x = 0,
   y = 8,
   width = 8,
-  height = 112,
+  height = 96,
   pattern = "ceiling",
 }
 

--- a/data/maps/components/obstacle_weakwall/obstacle_weakwall_w_000004_1.dat
+++ b/data/maps/components/obstacle_weakwall/obstacle_weakwall_w_000004_1.dat
@@ -9,69 +9,149 @@ properties{
   music = "same",
 }
 
+tile{
+  layer = 1,
+  x = 24,
+  y = 136,
+  width = 112,
+  height = 80,
+  pattern = "placeholder.floor.high",
+}
+
+tile{
+  layer = 1,
+  x = 8,
+  y = 208,
+  width = 24,
+  height = 24,
+  pattern = "high_wall_inner_corner.sw",
+}
+
+tile{
+  layer = 1,
+  x = 8,
+  y = 144,
+  width = 24,
+  height = 64,
+  pattern = "high_wall.w",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 208,
+  width = 96,
+  height = 24,
+  pattern = "high_wall.s",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 144,
+  width = 8,
+  height = 64,
+  pattern = "wall_border.high.w",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 200,
+  width = 96,
+  height = 8,
+  pattern = "wall_border.high.s",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 200,
+  width = 8,
+  height = 8,
+  pattern = "wall_border_inner_corner.high.sw",
+}
+
 dynamic_tile{
+  name = "treasure_obstacle_carpet",
   layer = 1,
   x = 48,
   y = 144,
+  pattern = "carpet.1",
   width = 32,
   height = 48,
-  name = "treasure_obstacle_carpet",
-  pattern = "carpet.1",
   enabled_at_start = true,
 }
 
 door{
+  name = "treasure_obstacle_block",
   layer = 1,
   x = 56,
   y = 168,
-  name = "treasure_obstacle_block",
   direction = 1,
   sprite = "entities/door_weak_block",
   opening_method = "explosion",
 }
 
 dynamic_tile{
+  name = "treasure_open_carpet",
   layer = 1,
   x = 80,
   y = 144,
+  pattern = "carpet.1",
   width = 32,
   height = 48,
-  name = "treasure_open_carpet",
-  pattern = "carpet.1",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "enemy_1",
   layer = 1,
   x = 80,
   y = 168,
+  pattern = "placeholder.enemy",
   width = 32,
   height = 32,
-  name = "enemy_1",
-  pattern = "placeholder.enemy",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "treasure_open_chest",
   layer = 1,
   x = 88,
   y = 152,
+  pattern = "placeholder.treasure_open",
   width = 16,
   height = 16,
-  name = "treasure_open_chest",
-  pattern = "placeholder.treasure_open",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "treasure_obstacle_chest",
   layer = 1,
   x = 56,
   y = 152,
+  pattern = "placeholder.treasure_obstacle",
   width = 16,
   height = 16,
-  name = "treasure_obstacle_chest",
-  pattern = "placeholder.treasure_obstacle",
   enabled_at_start = true,
 }
 
+tile{
+  layer = 2,
+  x = 0,
+  y = 232,
+  width = 136,
+  height = 8,
+  pattern = "ceiling",
+}
+
+tile{
+  layer = 2,
+  x = 0,
+  y = 136,
+  width = 8,
+  height = 96,
+  pattern = "ceiling",
+}
 

--- a/data/maps/components/treasure_bigkey/treasure_bigkey_000777_2.dat
+++ b/data/maps/components/treasure_bigkey/treasure_bigkey_000777_2.dat
@@ -11,6 +11,51 @@ properties{
 
 tile{
   layer = 1,
+  x = 24,
+  y = 24,
+  width = 272,
+  height = 192,
+  pattern = "placeholder.floor.high",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 64,
+  width = 8,
+  height = 112,
+  pattern = "wall_border.high.w",
+}
+
+tile{
+  layer = 1,
+  x = 64,
+  y = 32,
+  width = 192,
+  height = 8,
+  pattern = "wall_border.high.n",
+}
+
+tile{
+  layer = 1,
+  x = 64,
+  y = 200,
+  width = 192,
+  height = 8,
+  pattern = "wall_border.high.s",
+}
+
+tile{
+  layer = 1,
+  x = 280,
+  y = 64,
+  width = 8,
+  height = 112,
+  pattern = "wall_border.high.e",
+}
+
+tile{
+  layer = 1,
   x = 8,
   y = 8,
   width = 32,
@@ -738,102 +783,174 @@ tile{
   pattern = "wall_border_outer_corner.high.se",
 }
 
+tile{
+  layer = 1,
+  x = 64,
+  y = 8,
+  width = 64,
+  height = 24,
+  pattern = "high_wall.n",
+}
+
+tile{
+  layer = 1,
+  x = 192,
+  y = 8,
+  width = 64,
+  height = 24,
+  pattern = "high_wall.n",
+}
+
+tile{
+  layer = 1,
+  x = 8,
+  y = 64,
+  width = 24,
+  height = 32,
+  pattern = "high_wall.w",
+}
+
+tile{
+  layer = 1,
+  x = 8,
+  y = 144,
+  width = 24,
+  height = 32,
+  pattern = "high_wall.w",
+}
+
+tile{
+  layer = 1,
+  x = 288,
+  y = 64,
+  width = 24,
+  height = 32,
+  pattern = "high_wall.e",
+}
+
+tile{
+  layer = 1,
+  x = 288,
+  y = 144,
+  width = 24,
+  height = 32,
+  pattern = "high_wall.e",
+}
+
+tile{
+  layer = 1,
+  x = 64,
+  y = 208,
+  width = 64,
+  height = 24,
+  pattern = "high_wall.s",
+}
+
+tile{
+  layer = 1,
+  x = 192,
+  y = 208,
+  width = 64,
+  height = 24,
+  pattern = "high_wall.s",
+}
+
 dynamic_tile{
+  name = "chest",
   layer = 1,
   x = 144,
   y = 104,
+  pattern = "placeholder.big_chest",
   width = 32,
   height = 24,
-  name = "chest",
-  pattern = "placeholder.big_chest",
   enabled_at_start = true,
 }
 
 dynamic_tile{
-  layer = 1,
-  x = 88,
-  y = 40,
-  width = 16,
-  height = 16,
   name = "pot_1",
+  layer = 1,
+  x = 88,
+  y = 40,
   pattern = "placeholder.pot",
+  width = 16,
+  height = 16,
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "pot_4",
   layer = 1,
   x = 216,
   y = 40,
+  pattern = "placeholder.pot",
   width = 16,
   height = 16,
-  name = "pot_4",
-  pattern = "placeholder.pot",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "pot_5",
   layer = 1,
   x = 88,
   y = 184,
+  pattern = "placeholder.pot",
   width = 16,
   height = 16,
-  name = "pot_5",
-  pattern = "placeholder.pot",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "pot_8",
   layer = 1,
   x = 216,
   y = 184,
+  pattern = "placeholder.pot",
   width = 16,
   height = 16,
-  name = "pot_8",
-  pattern = "placeholder.pot",
   enabled_at_start = true,
 }
 
 dynamic_tile{
-  layer = 1,
-  x = 104,
-  y = 40,
-  width = 16,
-  height = 16,
   name = "pot_2",
+  layer = 1,
+  x = 104,
+  y = 40,
   pattern = "placeholder.pot",
+  width = 16,
+  height = 16,
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "pot_3",
   layer = 1,
   x = 200,
   y = 40,
+  pattern = "placeholder.pot",
   width = 16,
   height = 16,
-  name = "pot_3",
-  pattern = "placeholder.pot",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "pot_6",
   layer = 1,
   x = 104,
   y = 184,
+  pattern = "placeholder.pot",
   width = 16,
   height = 16,
-  name = "pot_6",
-  pattern = "placeholder.pot",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "pot_7",
   layer = 1,
   x = 200,
   y = 184,
+  pattern = "placeholder.pot",
   width = 16,
   height = 16,
-  name = "pot_7",
-  pattern = "placeholder.pot",
   enabled_at_start = true,
 }
 
@@ -841,7 +958,6 @@ block{
   layer = 1,
   x = 48,
   y = 85,
-  direction = -1,
   sprite = "entities/statue",
   pushable = false,
   pullable = false,
@@ -852,7 +968,6 @@ block{
   layer = 1,
   x = 64,
   y = 69,
-  direction = -1,
   sprite = "entities/statue",
   pushable = false,
   pullable = false,
@@ -863,7 +978,6 @@ block{
   layer = 1,
   x = 80,
   y = 53,
-  direction = -1,
   sprite = "entities/statue",
   pushable = false,
   pullable = false,
@@ -874,7 +988,6 @@ block{
   layer = 1,
   x = 240,
   y = 53,
-  direction = -1,
   sprite = "entities/statue",
   pushable = false,
   pullable = false,
@@ -885,7 +998,6 @@ block{
   layer = 1,
   x = 256,
   y = 69,
-  direction = -1,
   sprite = "entities/statue",
   pushable = false,
   pullable = false,
@@ -896,7 +1008,6 @@ block{
   layer = 1,
   x = 272,
   y = 85,
-  direction = -1,
   sprite = "entities/statue",
   pushable = false,
   pullable = false,
@@ -907,7 +1018,6 @@ block{
   layer = 1,
   x = 272,
   y = 165,
-  direction = -1,
   sprite = "entities/statue",
   pushable = false,
   pullable = false,
@@ -918,7 +1028,6 @@ block{
   layer = 1,
   x = 256,
   y = 181,
-  direction = -1,
   sprite = "entities/statue",
   pushable = false,
   pullable = false,
@@ -929,7 +1038,6 @@ block{
   layer = 1,
   x = 240,
   y = 197,
-  direction = -1,
   sprite = "entities/statue",
   pushable = false,
   pullable = false,
@@ -940,7 +1048,6 @@ block{
   layer = 1,
   x = 80,
   y = 197,
-  direction = -1,
   sprite = "entities/statue",
   pushable = false,
   pullable = false,
@@ -951,7 +1058,6 @@ block{
   layer = 1,
   x = 64,
   y = 181,
-  direction = -1,
   sprite = "entities/statue",
   pushable = false,
   pullable = false,
@@ -962,11 +1068,45 @@ block{
   layer = 1,
   x = 48,
   y = 165,
-  direction = -1,
   sprite = "entities/statue",
   pushable = false,
   pullable = false,
   maximum_moves = 1,
 }
 
+tile{
+  layer = 2,
+  x = 0,
+  y = 8,
+  width = 8,
+  height = 224,
+  pattern = "ceiling",
+}
+
+tile{
+  layer = 2,
+  x = 312,
+  y = 8,
+  width = 8,
+  height = 224,
+  pattern = "ceiling",
+}
+
+tile{
+  layer = 2,
+  x = 0,
+  y = 232,
+  width = 320,
+  height = 8,
+  pattern = "ceiling",
+}
+
+tile{
+  layer = 2,
+  x = 0,
+  y = 0,
+  width = 320,
+  height = 8,
+  pattern = "ceiling",
+}
 

--- a/data/maps/components/treasure_bigkey/treasure_bigkey_000777_3.dat
+++ b/data/maps/components/treasure_bigkey/treasure_bigkey_000777_3.dat
@@ -11,6 +11,87 @@ properties{
 
 tile{
   layer = 1,
+  x = 24,
+  y = 24,
+  width = 272,
+  height = 192,
+  pattern = "placeholder.floor.high",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 8,
+  width = 96,
+  height = 24,
+  pattern = "high_wall.n",
+}
+
+tile{
+  layer = 1,
+  x = 192,
+  y = 8,
+  width = 96,
+  height = 24,
+  pattern = "high_wall.n",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 208,
+  width = 96,
+  height = 24,
+  pattern = "high_wall.s",
+}
+
+tile{
+  layer = 1,
+  x = 192,
+  y = 208,
+  width = 96,
+  height = 24,
+  pattern = "high_wall.s",
+}
+
+tile{
+  layer = 1,
+  x = 288,
+  y = 144,
+  width = 24,
+  height = 64,
+  pattern = "high_wall.e",
+}
+
+tile{
+  layer = 1,
+  x = 288,
+  y = 32,
+  width = 24,
+  height = 64,
+  pattern = "high_wall.e",
+}
+
+tile{
+  layer = 1,
+  x = 8,
+  y = 144,
+  width = 24,
+  height = 64,
+  pattern = "high_wall.w",
+}
+
+tile{
+  layer = 1,
+  x = 8,
+  y = 32,
+  width = 24,
+  height = 64,
+  pattern = "high_wall.w",
+}
+
+tile{
+  layer = 1,
   x = 200,
   y = 56,
   width = 64,
@@ -333,6 +414,114 @@ tile{
   pattern = "placeholder.wall_statue.e",
 }
 
+tile{
+  layer = 1,
+  x = 8,
+  y = 8,
+  width = 24,
+  height = 24,
+  pattern = "high_wall_inner_corner.nw",
+}
+
+tile{
+  layer = 1,
+  x = 288,
+  y = 8,
+  width = 24,
+  height = 24,
+  pattern = "high_wall_inner_corner.ne",
+}
+
+tile{
+  layer = 1,
+  x = 288,
+  y = 208,
+  width = 24,
+  height = 24,
+  pattern = "high_wall_inner_corner.se",
+}
+
+tile{
+  layer = 1,
+  x = 8,
+  y = 208,
+  width = 24,
+  height = 24,
+  pattern = "high_wall_inner_corner.sw",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 32,
+  width = 256,
+  height = 8,
+  pattern = "wall_border.high.n",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 32,
+  width = 8,
+  height = 176,
+  pattern = "wall_border.high.w",
+}
+
+tile{
+  layer = 1,
+  x = 280,
+  y = 32,
+  width = 8,
+  height = 176,
+  pattern = "wall_border.high.e",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 200,
+  width = 256,
+  height = 8,
+  pattern = "wall_border.high.s",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 32,
+  width = 8,
+  height = 8,
+  pattern = "wall_border_inner_corner.high.nw",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 200,
+  width = 8,
+  height = 8,
+  pattern = "wall_border_inner_corner.high.sw",
+}
+
+tile{
+  layer = 1,
+  x = 280,
+  y = 200,
+  width = 8,
+  height = 8,
+  pattern = "wall_border_inner_corner.high.se",
+}
+
+tile{
+  layer = 1,
+  x = 280,
+  y = 32,
+  width = 8,
+  height = 8,
+  pattern = "wall_border_inner_corner.high.ne",
+}
+
 dynamic_tile{
   name = "chest",
   layer = 1,
@@ -344,4 +533,39 @@ dynamic_tile{
   enabled_at_start = true,
 }
 
+tile{
+  layer = 2,
+  x = 0,
+  y = 0,
+  width = 320,
+  height = 8,
+  pattern = "ceiling",
+}
+
+tile{
+  layer = 2,
+  x = 0,
+  y = 232,
+  width = 320,
+  height = 8,
+  pattern = "ceiling",
+}
+
+tile{
+  layer = 2,
+  x = 312,
+  y = 8,
+  width = 8,
+  height = 224,
+  pattern = "ceiling",
+}
+
+tile{
+  layer = 2,
+  x = 0,
+  y = 8,
+  width = 8,
+  height = 224,
+  pattern = "ceiling",
+}
 

--- a/data/maps/components/treasure_bigkey/treasure_bigkey_000777_4.dat
+++ b/data/maps/components/treasure_bigkey/treasure_bigkey_000777_4.dat
@@ -11,6 +11,51 @@ properties{
 
 tile{
   layer = 1,
+  x = 24,
+  y = 24,
+  width = 272,
+  height = 192,
+  pattern = "placeholder.floor.high",
+}
+
+tile{
+  layer = 1,
+  x = 280,
+  y = 96,
+  width = 8,
+  height = 48,
+  pattern = "wall_border.high.e",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 96,
+  width = 8,
+  height = 48,
+  pattern = "wall_border.high.w",
+}
+
+tile{
+  layer = 1,
+  x = 48,
+  y = 200,
+  width = 224,
+  height = 8,
+  pattern = "wall_border.high.s",
+}
+
+tile{
+  layer = 1,
+  x = 48,
+  y = 32,
+  width = 224,
+  height = 8,
+  pattern = "wall_border.high.n",
+}
+
+tile{
+  layer = 1,
   x = 280,
   y = 8,
   width = 32,
@@ -335,42 +380,6 @@ tile{
 
 tile{
   layer = 1,
-  x = 104,
-  y = 200,
-  width = 16,
-  height = 32,
-  pattern = "placeholder.wall_pillar.s",
-}
-
-tile{
-  layer = 1,
-  x = 200,
-  y = 200,
-  width = 16,
-  height = 32,
-  pattern = "placeholder.wall_pillar.s",
-}
-
-tile{
-  layer = 1,
-  x = 104,
-  y = 8,
-  width = 16,
-  height = 32,
-  pattern = "placeholder.wall_pillar.n",
-}
-
-tile{
-  layer = 1,
-  x = 200,
-  y = 8,
-  width = 16,
-  height = 32,
-  pattern = "placeholder.wall_pillar.n",
-}
-
-tile{
-  layer = 1,
   x = 32,
   y = 16,
   width = 16,
@@ -416,15 +425,6 @@ tile{
 
 tile{
   layer = 1,
-  x = 48,
-  y = 8,
-  width = 16,
-  height = 24,
-  pattern = "high_wall.n",
-}
-
-tile{
-  layer = 1,
   x = 24,
   y = 200,
   width = 16,
@@ -466,15 +466,6 @@ tile{
   width = 24,
   height = 24,
   pattern = "high_wall_outer_corner.sw",
-}
-
-tile{
-  layer = 1,
-  x = 48,
-  y = 208,
-  width = 16,
-  height = 24,
-  pattern = "high_wall.s",
 }
 
 tile{
@@ -569,30 +560,66 @@ tile{
 
 tile{
   layer = 1,
-  x = 256,
+  x = 48,
   y = 8,
-  width = 16,
+  width = 224,
   height = 24,
   pattern = "high_wall.n",
 }
 
 tile{
   layer = 1,
-  x = 256,
-  y = 208,
+  x = 104,
+  y = 8,
   width = 16,
+  height = 32,
+  pattern = "placeholder.wall_pillar.n",
+}
+
+tile{
+  layer = 1,
+  x = 200,
+  y = 8,
+  width = 16,
+  height = 32,
+  pattern = "placeholder.wall_pillar.n",
+}
+
+tile{
+  layer = 1,
+  x = 48,
+  y = 208,
+  width = 224,
   height = 24,
   pattern = "high_wall.s",
 }
 
+tile{
+  layer = 1,
+  x = 104,
+  y = 200,
+  width = 16,
+  height = 32,
+  pattern = "placeholder.wall_pillar.s",
+}
+
+tile{
+  layer = 1,
+  x = 200,
+  y = 200,
+  width = 16,
+  height = 32,
+  pattern = "placeholder.wall_pillar.s",
+}
+
 dynamic_tile{
+  name = "chest",
   layer = 1,
   x = 144,
   y = 104,
+  pattern = "placeholder.big_chest",
   width = 32,
   height = 24,
-  name = "chest",
-  pattern = "placeholder.big_chest",
   enabled_at_start = true,
 }
 
@@ -600,7 +627,6 @@ block{
   layer = 1,
   x = 112,
   y = 85,
-  direction = -1,
   sprite = "entities/statue",
   pushable = true,
   pullable = true,
@@ -611,7 +637,6 @@ block{
   layer = 1,
   x = 208,
   y = 85,
-  direction = -1,
   sprite = "entities/statue",
   pushable = true,
   pullable = true,
@@ -638,7 +663,6 @@ block{
   layer = 1,
   x = 112,
   y = 165,
-  direction = -1,
   sprite = "entities/statue",
   pushable = true,
   pullable = true,
@@ -649,7 +673,6 @@ block{
   layer = 1,
   x = 208,
   y = 165,
-  direction = -1,
   sprite = "entities/statue",
   pushable = true,
   pullable = true,
@@ -657,135 +680,170 @@ block{
 }
 
 dynamic_tile{
-  layer = 1,
-  x = 56,
-  y = 40,
-  width = 16,
-  height = 16,
   name = "pot_1",
+  layer = 1,
+  x = 56,
+  y = 40,
   pattern = "placeholder.pot",
+  width = 16,
+  height = 16,
   enabled_at_start = true,
 }
 
 dynamic_tile{
-  layer = 1,
-  x = 56,
-  y = 184,
-  width = 16,
-  height = 16,
   name = "pot_2",
+  layer = 1,
+  x = 56,
+  y = 184,
   pattern = "placeholder.pot",
+  width = 16,
+  height = 16,
   enabled_at_start = true,
 }
 
 dynamic_tile{
-  layer = 1,
-  x = 248,
-  y = 184,
-  width = 16,
-  height = 16,
   name = "pot_3",
+  layer = 1,
+  x = 248,
+  y = 184,
   pattern = "placeholder.pot",
+  width = 16,
+  height = 16,
   enabled_at_start = true,
 }
 
 dynamic_tile{
-  layer = 1,
-  x = 248,
-  y = 168,
-  width = 16,
-  height = 16,
   name = "pot_4",
+  layer = 1,
+  x = 248,
+  y = 168,
   pattern = "placeholder.pot",
+  width = 16,
+  height = 16,
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "pot_5",
   layer = 1,
   x = 248,
   y = 40,
+  pattern = "placeholder.pot",
   width = 16,
   height = 16,
-  name = "pot_5",
-  pattern = "placeholder.pot",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "pot_6",
   layer = 1,
   x = 56,
   y = 56,
+  pattern = "placeholder.pot",
   width = 16,
   height = 16,
-  name = "pot_6",
-  pattern = "placeholder.pot",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "pot_7",
   layer = 1,
   x = 56,
   y = 168,
+  pattern = "placeholder.pot",
   width = 16,
   height = 16,
-  name = "pot_7",
-  pattern = "placeholder.pot",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "pot_8",
   layer = 1,
   x = 248,
   y = 56,
+  pattern = "placeholder.pot",
   width = 16,
   height = 16,
-  name = "pot_8",
-  pattern = "placeholder.pot",
   enabled_at_start = true,
 }
 
 dynamic_tile{
-  layer = 1,
-  x = 72,
-  y = 184,
-  width = 16,
-  height = 16,
   name = "pot_9",
+  layer = 1,
+  x = 72,
+  y = 184,
   pattern = "placeholder.pot",
+  width = 16,
+  height = 16,
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "pot_10",
   layer = 1,
   x = 72,
   y = 40,
+  pattern = "placeholder.pot",
   width = 16,
   height = 16,
-  name = "pot_10",
-  pattern = "placeholder.pot",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "pot_11",
   layer = 1,
   x = 232,
   y = 40,
+  pattern = "placeholder.pot",
   width = 16,
   height = 16,
-  name = "pot_11",
-  pattern = "placeholder.pot",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "pot_12",
   layer = 1,
   x = 232,
   y = 184,
+  pattern = "placeholder.pot",
   width = 16,
   height = 16,
-  name = "pot_12",
-  pattern = "placeholder.pot",
   enabled_at_start = true,
 }
 
+tile{
+  layer = 2,
+  x = 0,
+  y = 0,
+  width = 320,
+  height = 8,
+  pattern = "ceiling",
+}
+
+tile{
+  layer = 2,
+  x = 0,
+  y = 232,
+  width = 320,
+  height = 8,
+  pattern = "ceiling",
+}
+
+tile{
+  layer = 2,
+  x = 312,
+  y = 8,
+  width = 8,
+  height = 224,
+  pattern = "ceiling",
+}
+
+tile{
+  layer = 2,
+  x = 0,
+  y = 8,
+  width = 8,
+  height = 224,
+  pattern = "ceiling",
+}
 

--- a/data/maps/components/treasure_bigkey/treasure_bigkey_200777_1.dat
+++ b/data/maps/components/treasure_bigkey/treasure_bigkey_200777_1.dat
@@ -11,6 +11,51 @@ properties{
 
 tile{
   layer = 1,
+  x = 24,
+  y = 24,
+  width = 272,
+  height = 192,
+  pattern = "placeholder.floor.high",
+}
+
+tile{
+  layer = 1,
+  x = 280,
+  y = 96,
+  width = 8,
+  height = 96,
+  pattern = "wall_border.high.e",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 96,
+  width = 8,
+  height = 96,
+  pattern = "wall_border.high.w",
+}
+
+tile{
+  layer = 1,
+  x = 80,
+  y = 200,
+  width = 160,
+  height = 8,
+  pattern = "wall_border.high.s",
+}
+
+tile{
+  layer = 1,
+  x = 80,
+  y = 32,
+  width = 160,
+  height = 8,
+  pattern = "wall_border.high.n",
+}
+
+tile{
+  layer = 1,
   x = 128,
   y = 72,
   width = 64,
@@ -612,6 +657,51 @@ tile{
   pattern = "ceiling",
 }
 
+tile{
+  layer = 1,
+  x = 80,
+  y = 8,
+  width = 160,
+  height = 24,
+  pattern = "high_wall.n",
+}
+
+tile{
+  layer = 1,
+  x = 80,
+  y = 208,
+  width = 48,
+  height = 24,
+  pattern = "high_wall.s",
+}
+
+tile{
+  layer = 1,
+  x = 192,
+  y = 208,
+  width = 48,
+  height = 24,
+  pattern = "high_wall.s",
+}
+
+tile{
+  layer = 1,
+  x = 288,
+  y = 144,
+  width = 24,
+  height = 48,
+  pattern = "high_wall.e",
+}
+
+tile{
+  layer = 1,
+  x = 8,
+  y = 144,
+  width = 24,
+  height = 48,
+  pattern = "high_wall.w",
+}
+
 dynamic_tile{
   name = "chest",
   layer = 1,
@@ -645,4 +735,39 @@ dynamic_tile{
   enabled_at_start = true,
 }
 
+tile{
+  layer = 2,
+  x = 0,
+  y = 0,
+  width = 320,
+  height = 8,
+  pattern = "ceiling",
+}
+
+tile{
+  layer = 2,
+  x = 0,
+  y = 232,
+  width = 320,
+  height = 8,
+  pattern = "ceiling",
+}
+
+tile{
+  layer = 2,
+  x = 0,
+  y = 8,
+  width = 8,
+  height = 224,
+  pattern = "ceiling",
+}
+
+tile{
+  layer = 2,
+  x = 312,
+  y = 8,
+  width = 8,
+  height = 224,
+  pattern = "ceiling",
+}
 

--- a/data/maps/components/treasure_bigkey/treasure_bigkey_202777_3.dat
+++ b/data/maps/components/treasure_bigkey/treasure_bigkey_202777_3.dat
@@ -10,57 +10,66 @@ properties{
 }
 
 tile{
-  layer = 1,
+  layer = 0,
   x = 32,
   y = 0,
-  width = 72,
-  height = 88,
+  width = 264,
+  height = 232,
   pattern = "hole",
 }
 
 tile{
   layer = 1,
-  x = 216,
+  x = 24,
+  y = 88,
+  width = 272,
+  height = 64,
+  pattern = "placeholder.floor.high",
+}
+
+tile{
+  layer = 1,
+  x = 8,
   y = 0,
-  width = 72,
-  height = 88,
-  pattern = "hole",
+  width = 24,
+  height = 96,
+  pattern = "high_wall.w",
 }
 
 tile{
   layer = 1,
-  x = 32,
-  y = 152,
-  width = 72,
-  height = 88,
-  pattern = "hole",
+  x = 8,
+  y = 144,
+  width = 24,
+  height = 96,
+  pattern = "high_wall.w",
 }
 
 tile{
   layer = 1,
-  x = 216,
-  y = 152,
-  width = 72,
-  height = 88,
-  pattern = "hole",
+  x = 288,
+  y = 0,
+  width = 24,
+  height = 96,
+  pattern = "high_wall.e",
+}
+
+tile{
+  layer = 1,
+  x = 288,
+  y = 144,
+  width = 24,
+  height = 96,
+  pattern = "high_wall.e",
 }
 
 tile{
   layer = 1,
   x = 104,
-  y = 0,
+  y = 56,
   width = 112,
-  height = 56,
-  pattern = "hole",
-}
-
-tile{
-  layer = 1,
-  x = 104,
-  y = 184,
-  width = 112,
-  height = 56,
-  pattern = "hole",
+  height = 128,
+  pattern = "placeholder.floor.high",
 }
 
 tile{
@@ -290,42 +299,6 @@ tile{
 
 tile{
   layer = 1,
-  x = 8,
-  y = 208,
-  width = 24,
-  height = 16,
-  pattern = "high_wall.w",
-}
-
-tile{
-  layer = 1,
-  x = 288,
-  y = 208,
-  width = 24,
-  height = 16,
-  pattern = "high_wall.e",
-}
-
-tile{
-  layer = 1,
-  x = 8,
-  y = 16,
-  width = 24,
-  height = 16,
-  pattern = "high_wall.w",
-}
-
-tile{
-  layer = 1,
-  x = 288,
-  y = 16,
-  width = 24,
-  height = 16,
-  pattern = "high_wall.e",
-}
-
-tile{
-  layer = 1,
   x = 16,
   y = 184,
   width = 16,
@@ -358,60 +331,78 @@ tile{
   width = 16,
   height = 32,
   pattern = "wall_torch.e",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 88,
+  width = 8,
+  height = 64,
+  pattern = "wall_border.high.w",
+}
+
+tile{
+  layer = 1,
+  x = 280,
+  y = 88,
+  width = 8,
+  height = 64,
+  pattern = "wall_border.high.e",
 }
 
 dynamic_tile{
+  name = "chest",
   layer = 1,
   x = 144,
   y = 88,
+  pattern = "placeholder.big_chest",
   width = 32,
   height = 24,
-  name = "chest",
-  pattern = "placeholder.big_chest",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "pot_5",
   layer = 1,
   x = 120,
   y = 152,
+  pattern = "placeholder.pot",
   width = 16,
   height = 16,
-  name = "pot_5",
-  pattern = "placeholder.pot",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "pot_2",
   layer = 1,
   x = 136,
   y = 152,
+  pattern = "placeholder.pot",
   width = 16,
   height = 16,
-  name = "pot_2",
-  pattern = "placeholder.pot",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "pot_3",
   layer = 1,
   x = 168,
   y = 152,
+  pattern = "placeholder.pot",
   width = 16,
   height = 16,
-  name = "pot_3",
-  pattern = "placeholder.pot",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "pot_4",
   layer = 1,
   x = 184,
   y = 152,
+  pattern = "placeholder.pot",
   width = 16,
   height = 16,
-  name = "pot_4",
-  pattern = "placeholder.pot",
   enabled_at_start = true,
 }
 
@@ -453,42 +444,6 @@ tile{
 
 tile{
   layer = 2,
-  x = 8,
-  y = 0,
-  width = 24,
-  height = 16,
-  pattern = "high_wall.w",
-}
-
-tile{
-  layer = 2,
-  x = 8,
-  y = 224,
-  width = 24,
-  height = 16,
-  pattern = "high_wall.w",
-}
-
-tile{
-  layer = 2,
-  x = 288,
-  y = 0,
-  width = 24,
-  height = 16,
-  pattern = "high_wall.e",
-}
-
-tile{
-  layer = 2,
-  x = 288,
-  y = 224,
-  width = 24,
-  height = 16,
-  pattern = "high_wall.e",
-}
-
-tile{
-  layer = 2,
   x = 32,
   y = 0,
   width = 16,
@@ -523,4 +478,21 @@ tile{
   pattern = "chasm_wall.e",
 }
 
+tile{
+  layer = 2,
+  x = 0,
+  y = 0,
+  width = 8,
+  height = 240,
+  pattern = "ceiling",
+}
+
+tile{
+  layer = 2,
+  x = 312,
+  y = 0,
+  width = 8,
+  height = 240,
+  pattern = "ceiling",
+}
 

--- a/data/maps/components/treasure_bigkey/treasure_bigkey_202777_water.dat
+++ b/data/maps/components/treasure_bigkey/treasure_bigkey_202777_water.dat
@@ -11,6 +11,123 @@ properties{
 
 tile{
   layer = 1,
+  x = 24,
+  y = 104,
+  width = 272,
+  height = 32,
+  pattern = "placeholder.floor.high",
+}
+
+tile{
+  layer = 1,
+  x = 8,
+  y = 8,
+  width = 24,
+  height = 24,
+  pattern = "high_wall_inner_corner.nw",
+}
+
+tile{
+  layer = 1,
+  x = 288,
+  y = 8,
+  width = 24,
+  height = 24,
+  pattern = "high_wall_inner_corner.ne",
+}
+
+tile{
+  layer = 1,
+  x = 8,
+  y = 208,
+  width = 24,
+  height = 24,
+  pattern = "high_wall_inner_corner.sw",
+}
+
+tile{
+  layer = 1,
+  x = 288,
+  y = 208,
+  width = 24,
+  height = 24,
+  pattern = "high_wall_inner_corner.se",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 8,
+  width = 256,
+  height = 24,
+  pattern = "high_wall.n",
+}
+
+tile{
+  layer = 1,
+  x = 8,
+  y = 144,
+  width = 24,
+  height = 64,
+  pattern = "high_wall.w",
+}
+
+tile{
+  layer = 1,
+  x = 8,
+  y = 32,
+  width = 24,
+  height = 64,
+  pattern = "high_wall.w",
+}
+
+tile{
+  layer = 1,
+  x = 288,
+  y = 32,
+  width = 24,
+  height = 64,
+  pattern = "high_wall.e",
+}
+
+tile{
+  layer = 1,
+  x = 288,
+  y = 144,
+  width = 24,
+  height = 64,
+  pattern = "high_wall.e",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 208,
+  width = 256,
+  height = 24,
+  pattern = "high_wall.s",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 104,
+  width = 8,
+  height = 32,
+  pattern = "wall_border.high.w",
+}
+
+tile{
+  layer = 1,
+  x = 280,
+  y = 104,
+  width = 8,
+  height = 32,
+  pattern = "wall_border.high.e",
+}
+
+tile{
+  layer = 1,
   x = 48,
   y = 88,
   width = 24,
@@ -1018,14 +1135,49 @@ tile{
 }
 
 dynamic_tile{
+  name = "chest",
   layer = 1,
   x = 144,
   y = 96,
+  pattern = "placeholder.big_chest",
   width = 32,
   height = 24,
-  name = "chest",
-  pattern = "placeholder.big_chest",
   enabled_at_start = true,
 }
 
+tile{
+  layer = 2,
+  x = 0,
+  y = 0,
+  width = 320,
+  height = 8,
+  pattern = "ceiling",
+}
+
+tile{
+  layer = 2,
+  x = 0,
+  y = 232,
+  width = 320,
+  height = 8,
+  pattern = "ceiling",
+}
+
+tile{
+  layer = 2,
+  x = 312,
+  y = 8,
+  width = 8,
+  height = 224,
+  pattern = "ceiling",
+}
+
+tile{
+  layer = 2,
+  x = 0,
+  y = 8,
+  width = 8,
+  height = 224,
+  pattern = "ceiling",
+}
 

--- a/data/maps/components/treasure_open/treasure_open_000077_1.dat
+++ b/data/maps/components/treasure_open/treasure_open_000077_1.dat
@@ -11,6 +11,33 @@ properties{
 
 tile{
   layer = 1,
+  x = 24,
+  y = 104,
+  width = 272,
+  height = 112,
+  pattern = "placeholder.floor.high",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 112,
+  width = 8,
+  height = 96,
+  pattern = "wall_border.high.w",
+}
+
+tile{
+  layer = 1,
+  x = 280,
+  y = 112,
+  width = 8,
+  height = 96,
+  pattern = "wall_border.high.e",
+}
+
+tile{
+  layer = 1,
   x = 136,
   y = 136,
   width = 48,
@@ -27,11 +54,83 @@ tile{
   pattern = "carpet.1",
 }
 
+tile{
+  layer = 1,
+  x = 32,
+  y = 208,
+  width = 256,
+  height = 24,
+  pattern = "high_wall.s",
+}
+
+tile{
+  layer = 1,
+  x = 288,
+  y = 208,
+  width = 24,
+  height = 24,
+  pattern = "high_wall_inner_corner.se",
+}
+
+tile{
+  layer = 1,
+  x = 8,
+  y = 208,
+  width = 24,
+  height = 24,
+  pattern = "high_wall_inner_corner.sw",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 200,
+  width = 256,
+  height = 8,
+  pattern = "wall_border.high.s",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 200,
+  width = 8,
+  height = 8,
+  pattern = "wall_border_inner_corner.high.sw",
+}
+
+tile{
+  layer = 1,
+  x = 280,
+  y = 200,
+  width = 8,
+  height = 8,
+  pattern = "wall_border_inner_corner.high.se",
+}
+
+tile{
+  layer = 1,
+  x = 8,
+  y = 144,
+  width = 24,
+  height = 64,
+  pattern = "high_wall.w",
+}
+
+tile{
+  layer = 1,
+  x = 288,
+  y = 144,
+  width = 24,
+  height = 64,
+  pattern = "high_wall.e",
+}
+
 switch{
+  name = "switch",
   layer = 1,
   x = 0,
   y = 0,
-  name = "switch",
   subtype = "walkable",
   sprite = "entities/switch",
   needs_block = false,
@@ -39,124 +138,150 @@ switch{
 }
 
 dynamic_tile{
+  name = "pot_8",
   layer = 1,
   x = 72,
   y = 136,
+  pattern = "placeholder.pot",
   width = 16,
   height = 16,
-  name = "pot_8",
-  pattern = "placeholder.pot",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "pot_2",
   layer = 1,
   x = 56,
   y = 152,
+  pattern = "placeholder.pot",
   width = 16,
   height = 16,
-  name = "pot_2",
-  pattern = "placeholder.pot",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "pot_3",
   layer = 1,
   x = 72,
   y = 168,
+  pattern = "placeholder.pot",
   width = 16,
   height = 16,
-  name = "pot_3",
-  pattern = "placeholder.pot",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "pot_4",
   layer = 1,
   x = 88,
   y = 152,
+  pattern = "placeholder.pot",
   width = 16,
   height = 16,
-  name = "pot_4",
-  pattern = "placeholder.pot",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "pot_5",
   layer = 1,
   x = 232,
   y = 136,
+  pattern = "placeholder.pot",
   width = 16,
   height = 16,
-  name = "pot_5",
-  pattern = "placeholder.pot",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "pot_6",
   layer = 1,
   x = 216,
   y = 152,
+  pattern = "placeholder.pot",
   width = 16,
   height = 16,
-  name = "pot_6",
-  pattern = "placeholder.pot",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "pot_7",
   layer = 1,
   x = 232,
   y = 168,
+  pattern = "placeholder.pot",
   width = 16,
   height = 16,
-  name = "pot_7",
-  pattern = "placeholder.pot",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "pot_9",
   layer = 1,
   x = 248,
   y = 152,
+  pattern = "placeholder.pot",
   width = 16,
   height = 16,
-  name = "pot_9",
-  pattern = "placeholder.pot",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "enemy_1",
   layer = 1,
   x = 104,
   y = 136,
+  pattern = "placeholder.enemy",
   width = 32,
   height = 32,
-  name = "enemy_1",
-  pattern = "placeholder.enemy",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "enemy_2",
   layer = 1,
   x = 184,
   y = 136,
+  pattern = "placeholder.enemy",
   width = 32,
   height = 32,
-  name = "enemy_2",
-  pattern = "placeholder.enemy",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "chest",
   layer = 1,
   x = 152,
   y = 152,
+  pattern = "placeholder.treasure_open",
   width = 16,
   height = 16,
-  name = "chest",
-  pattern = "placeholder.treasure_open",
   enabled_at_start = true,
 }
 
+tile{
+  layer = 2,
+  x = 0,
+  y = 232,
+  width = 320,
+  height = 8,
+  pattern = "ceiling",
+}
+
+tile{
+  layer = 2,
+  x = 0,
+  y = 104,
+  width = 8,
+  height = 128,
+  pattern = "ceiling",
+}
+
+tile{
+  layer = 2,
+  x = 312,
+  y = 104,
+  width = 8,
+  height = 128,
+  pattern = "ceiling",
+}
 

--- a/data/maps/components/treasure_open/treasure_open_000444_1.dat
+++ b/data/maps/components/treasure_open/treasure_open_000444_1.dat
@@ -11,6 +11,15 @@ properties{
 
 tile{
   layer = 1,
+  x = 24,
+  y = 24,
+  width = 112,
+  height = 192,
+  pattern = "placeholder.floor.high",
+}
+
+tile{
+  layer = 1,
   x = 56,
   y = 40,
   width = 64,
@@ -47,20 +56,101 @@ tile{
 
 tile{
   layer = 1,
-  x = 64,
+  x = 32,
   y = 32,
-  width = 48,
+  width = 96,
   height = 8,
   pattern = "wall_border.high.n",
 }
 
 tile{
   layer = 1,
-  x = 64,
+  x = 32,
   y = 200,
-  width = 48,
+  width = 96,
   height = 8,
   pattern = "wall_border.high.s",
+}
+
+tile{
+  layer = 1,
+  x = 8,
+  y = 8,
+  width = 24,
+  height = 24,
+  pattern = "high_wall_inner_corner.nw",
+}
+
+tile{
+  layer = 1,
+  x = 8,
+  y = 208,
+  width = 24,
+  height = 24,
+  pattern = "high_wall_inner_corner.sw",
+}
+
+tile{
+  layer = 1,
+  x = 8,
+  y = 144,
+  width = 24,
+  height = 64,
+  pattern = "high_wall.w",
+}
+
+tile{
+  layer = 1,
+  x = 8,
+  y = 32,
+  width = 24,
+  height = 64,
+  pattern = "high_wall.w",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 8,
+  width = 96,
+  height = 24,
+  pattern = "high_wall.n",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 208,
+  width = 96,
+  height = 24,
+  pattern = "high_wall.s",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 32,
+  width = 8,
+  height = 176,
+  pattern = "wall_border.high.w",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 200,
+  width = 8,
+  height = 8,
+  pattern = "wall_border_inner_corner.high.sw",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 32,
+  width = 8,
+  height = 8,
+  pattern = "wall_border_inner_corner.high.nw",
 }
 
 dynamic_tile{
@@ -96,4 +186,30 @@ dynamic_tile{
   enabled_at_start = true,
 }
 
+tile{
+  layer = 2,
+  x = 0,
+  y = 0,
+  width = 136,
+  height = 8,
+  pattern = "ceiling",
+}
+
+tile{
+  layer = 2,
+  x = 0,
+  y = 232,
+  width = 136,
+  height = 8,
+  pattern = "ceiling",
+}
+
+tile{
+  layer = 2,
+  x = 0,
+  y = 8,
+  width = 8,
+  height = 224,
+  pattern = "ceiling",
+}
 

--- a/data/maps/components/treasure_open/treasure_open_000770_1.dat
+++ b/data/maps/components/treasure_open/treasure_open_000770_1.dat
@@ -11,6 +11,15 @@ properties{
 
 tile{
   layer = 1,
+  x = 24,
+  y = 24,
+  width = 272,
+  height = 112,
+  pattern = "placeholder.floor.high",
+}
+
+tile{
+  layer = 1,
   x = 136,
   y = 56,
   width = 48,
@@ -27,22 +36,121 @@ tile{
   pattern = "carpet.1",
 }
 
+tile{
+  layer = 1,
+  x = 8,
+  y = 8,
+  width = 24,
+  height = 24,
+  pattern = "high_wall_inner_corner.nw",
+}
+
+tile{
+  layer = 1,
+  x = 288,
+  y = 8,
+  width = 24,
+  height = 24,
+  pattern = "high_wall_inner_corner.ne",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 8,
+  width = 96,
+  height = 24,
+  pattern = "high_wall.n",
+}
+
+tile{
+  layer = 1,
+  x = 192,
+  y = 8,
+  width = 96,
+  height = 24,
+  pattern = "high_wall.n",
+}
+
+tile{
+  layer = 1,
+  x = 8,
+  y = 32,
+  width = 24,
+  height = 64,
+  pattern = "high_wall.w",
+}
+
+tile{
+  layer = 1,
+  x = 288,
+  y = 32,
+  width = 24,
+  height = 64,
+  pattern = "high_wall.e",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 32,
+  width = 256,
+  height = 8,
+  pattern = "wall_border.high.n",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 32,
+  width = 8,
+  height = 96,
+  pattern = "wall_border.high.w",
+}
+
+tile{
+  layer = 1,
+  x = 280,
+  y = 32,
+  width = 8,
+  height = 96,
+  pattern = "wall_border.high.e",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 32,
+  width = 8,
+  height = 8,
+  pattern = "wall_border_inner_corner.high.nw",
+}
+
+tile{
+  layer = 1,
+  x = 280,
+  y = 32,
+  width = 8,
+  height = 8,
+  pattern = "wall_border_inner_corner.high.ne",
+}
+
 dynamic_tile{
+  name = "pot_1",
   layer = 1,
   x = 72,
   y = 72,
+  pattern = "placeholder.pot",
   width = 16,
   height = 16,
-  name = "pot_1",
-  pattern = "placeholder.pot",
   enabled_at_start = true,
 }
 
 switch{
-  layer = 1,
-  x = 0,
-  y = 0,
   name = "switch",
+  layer = 1,
+  x = -8,
+  y = -8,
   subtype = "walkable",
   sprite = "entities/switch",
   needs_block = false,
@@ -50,91 +158,117 @@ switch{
 }
 
 dynamic_tile{
+  name = "pot_2",
   layer = 1,
   x = 88,
   y = 72,
+  pattern = "placeholder.pot",
   width = 16,
   height = 16,
-  name = "pot_2",
-  pattern = "placeholder.pot",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "pot_3",
   layer = 1,
   x = 104,
   y = 72,
+  pattern = "placeholder.pot",
   width = 16,
   height = 16,
-  name = "pot_3",
-  pattern = "placeholder.pot",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "pot_4",
   layer = 1,
   x = 200,
   y = 72,
+  pattern = "placeholder.pot",
   width = 16,
   height = 16,
-  name = "pot_4",
-  pattern = "placeholder.pot",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "pot_5",
   layer = 1,
   x = 216,
   y = 72,
+  pattern = "placeholder.pot",
   width = 16,
   height = 16,
-  name = "pot_5",
-  pattern = "placeholder.pot",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "pot_6",
   layer = 1,
   x = 232,
   y = 72,
+  pattern = "placeholder.pot",
   width = 16,
   height = 16,
-  name = "pot_6",
-  pattern = "placeholder.pot",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "enemy_2",
   layer = 1,
   x = 40,
   y = 64,
+  pattern = "placeholder.enemy",
   width = 32,
   height = 32,
-  name = "enemy_2",
-  pattern = "placeholder.enemy",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "enemy_4",
   layer = 1,
   x = 248,
   y = 64,
+  pattern = "placeholder.enemy",
   width = 32,
   height = 32,
-  name = "enemy_4",
-  pattern = "placeholder.enemy",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "chest",
   layer = 1,
   x = 152,
   y = 72,
+  pattern = "placeholder.treasure_open",
   width = 16,
   height = 16,
-  name = "chest",
-  pattern = "placeholder.treasure_open",
   enabled_at_start = true,
 }
 
+tile{
+  layer = 2,
+  x = 0,
+  y = 8,
+  width = 8,
+  height = 128,
+  pattern = "ceiling",
+}
+
+tile{
+  layer = 2,
+  x = 0,
+  y = 0,
+  width = 320,
+  height = 8,
+  pattern = "ceiling",
+}
+
+tile{
+  layer = 2,
+  x = 312,
+  y = 8,
+  width = 8,
+  height = 128,
+  pattern = "ceiling",
+}
 

--- a/data/maps/components/treasure_open/treasure_open_000777_1.dat
+++ b/data/maps/components/treasure_open/treasure_open_000777_1.dat
@@ -11,6 +11,15 @@ properties{
 
 tile{
   layer = 1,
+  x = 24,
+  y = 24,
+  width = 272,
+  height = 192,
+  pattern = "placeholder.floor.high",
+}
+
+tile{
+  layer = 1,
   x = 136,
   y = 96,
   width = 48,
@@ -153,11 +162,190 @@ tile{
   pattern = "carpet.1",
 }
 
+tile{
+  layer = 1,
+  x = 8,
+  y = 8,
+  width = 24,
+  height = 24,
+  pattern = "high_wall_inner_corner.nw",
+}
+
+tile{
+  layer = 1,
+  x = 288,
+  y = 8,
+  width = 24,
+  height = 24,
+  pattern = "high_wall_inner_corner.ne",
+}
+
+tile{
+  layer = 1,
+  x = 8,
+  y = 208,
+  width = 24,
+  height = 24,
+  pattern = "high_wall_inner_corner.sw",
+}
+
+tile{
+  layer = 1,
+  x = 288,
+  y = 208,
+  width = 24,
+  height = 24,
+  pattern = "high_wall_inner_corner.se",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 8,
+  width = 96,
+  height = 24,
+  pattern = "high_wall.n",
+}
+
+tile{
+  layer = 1,
+  x = 192,
+  y = 8,
+  width = 96,
+  height = 24,
+  pattern = "high_wall.n",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 208,
+  width = 96,
+  height = 24,
+  pattern = "high_wall.s",
+}
+
+tile{
+  layer = 1,
+  x = 192,
+  y = 208,
+  width = 96,
+  height = 24,
+  pattern = "high_wall.s",
+}
+
+tile{
+  layer = 1,
+  x = 8,
+  y = 32,
+  width = 24,
+  height = 64,
+  pattern = "high_wall.w",
+}
+
+tile{
+  layer = 1,
+  x = 8,
+  y = 144,
+  width = 24,
+  height = 64,
+  pattern = "high_wall.w",
+}
+
+tile{
+  layer = 1,
+  x = 288,
+  y = 144,
+  width = 24,
+  height = 64,
+  pattern = "high_wall.e",
+}
+
+tile{
+  layer = 1,
+  x = 288,
+  y = 32,
+  width = 24,
+  height = 64,
+  pattern = "high_wall.e",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 32,
+  width = 256,
+  height = 8,
+  pattern = "wall_border.high.n",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 200,
+  width = 256,
+  height = 8,
+  pattern = "wall_border.high.s",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 32,
+  width = 8,
+  height = 176,
+  pattern = "wall_border.high.w",
+}
+
+tile{
+  layer = 1,
+  x = 280,
+  y = 32,
+  width = 8,
+  height = 176,
+  pattern = "wall_border.high.e",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 32,
+  width = 8,
+  height = 8,
+  pattern = "wall_border_inner_corner.high.nw",
+}
+
+tile{
+  layer = 1,
+  x = 280,
+  y = 32,
+  width = 8,
+  height = 8,
+  pattern = "wall_border_inner_corner.high.ne",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 200,
+  width = 8,
+  height = 8,
+  pattern = "wall_border_inner_corner.high.sw",
+}
+
+tile{
+  layer = 1,
+  x = 280,
+  y = 200,
+  width = 8,
+  height = 8,
+  pattern = "wall_border_inner_corner.high.se",
+}
+
 block{
   layer = 1,
   x = 96,
   y = 125,
-  direction = -1,
   sprite = "entities/statue",
   pushable = true,
   pullable = true,
@@ -208,14 +396,49 @@ block{
 }
 
 dynamic_tile{
+  name = "chest",
   layer = 1,
   x = 152,
   y = 112,
+  pattern = "placeholder.treasure_open",
   width = 16,
   height = 16,
-  name = "chest",
-  pattern = "placeholder.treasure_open",
   enabled_at_start = true,
 }
 
+tile{
+  layer = 2,
+  x = 0,
+  y = 0,
+  width = 320,
+  height = 8,
+  pattern = "ceiling",
+}
+
+tile{
+  layer = 2,
+  x = 0,
+  y = 232,
+  width = 320,
+  height = 8,
+  pattern = "ceiling",
+}
+
+tile{
+  layer = 2,
+  x = 312,
+  y = 8,
+  width = 8,
+  height = 224,
+  pattern = "ceiling",
+}
+
+tile{
+  layer = 2,
+  x = 0,
+  y = 8,
+  width = 8,
+  height = 224,
+  pattern = "ceiling",
+}
 

--- a/data/maps/components/treasure_open/treasure_open_000777_3.dat
+++ b/data/maps/components/treasure_open/treasure_open_000777_3.dat
@@ -11,6 +11,33 @@ properties{
 
 tile{
   layer = 1,
+  x = 24,
+  y = 24,
+  width = 272,
+  height = 192,
+  pattern = "placeholder.floor.high",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 8,
+  width = 96,
+  height = 24,
+  pattern = "high_wall.n",
+}
+
+tile{
+  layer = 1,
+  x = 192,
+  y = 8,
+  width = 96,
+  height = 24,
+  pattern = "high_wall.n",
+}
+
+tile{
+  layer = 1,
   x = 128,
   y = 96,
   width = 64,
@@ -45,6 +72,168 @@ tile{
   pattern = "placeholder.wall_statue.n",
 }
 
+tile{
+  layer = 1,
+  x = 8,
+  y = 8,
+  width = 24,
+  height = 24,
+  pattern = "high_wall_inner_corner.nw",
+}
+
+tile{
+  layer = 1,
+  x = 288,
+  y = 8,
+  width = 24,
+  height = 24,
+  pattern = "high_wall_inner_corner.ne",
+}
+
+tile{
+  layer = 1,
+  x = 8,
+  y = 208,
+  width = 24,
+  height = 24,
+  pattern = "high_wall_inner_corner.sw",
+}
+
+tile{
+  layer = 1,
+  x = 288,
+  y = 208,
+  width = 24,
+  height = 24,
+  pattern = "high_wall_inner_corner.se",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 208,
+  width = 96,
+  height = 24,
+  pattern = "high_wall.s",
+}
+
+tile{
+  layer = 1,
+  x = 192,
+  y = 208,
+  width = 96,
+  height = 24,
+  pattern = "high_wall.s",
+}
+
+tile{
+  layer = 1,
+  x = 8,
+  y = 144,
+  width = 24,
+  height = 64,
+  pattern = "high_wall.w",
+}
+
+tile{
+  layer = 1,
+  x = 8,
+  y = 32,
+  width = 24,
+  height = 64,
+  pattern = "high_wall.w",
+}
+
+tile{
+  layer = 1,
+  x = 288,
+  y = 32,
+  width = 24,
+  height = 64,
+  pattern = "high_wall.e",
+}
+
+tile{
+  layer = 1,
+  x = 288,
+  y = 144,
+  width = 24,
+  height = 64,
+  pattern = "high_wall.e",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 32,
+  width = 256,
+  height = 8,
+  pattern = "wall_border.high.n",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 32,
+  width = 8,
+  height = 176,
+  pattern = "wall_border.high.w",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 200,
+  width = 256,
+  height = 8,
+  pattern = "wall_border.high.s",
+}
+
+tile{
+  layer = 1,
+  x = 280,
+  y = 32,
+  width = 8,
+  height = 176,
+  pattern = "wall_border.high.e",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 32,
+  width = 8,
+  height = 8,
+  pattern = "wall_border_inner_corner.high.nw",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 200,
+  width = 8,
+  height = 8,
+  pattern = "wall_border_inner_corner.high.sw",
+}
+
+tile{
+  layer = 1,
+  x = 280,
+  y = 200,
+  width = 8,
+  height = 8,
+  pattern = "wall_border_inner_corner.high.se",
+}
+
+tile{
+  layer = 1,
+  x = 280,
+  y = 32,
+  width = 8,
+  height = 8,
+  pattern = "wall_border_inner_corner.high.ne",
+}
+
 enemy{
   layer = 1,
   x = 40,
@@ -78,58 +267,93 @@ enemy{
 }
 
 dynamic_tile{
-  layer = 1,
-  x = 64,
-  y = 48,
-  width = 32,
-  height = 32,
   name = "enemy_5",
+  layer = 1,
+  x = 64,
+  y = 48,
   pattern = "placeholder.enemy",
+  width = 32,
+  height = 32,
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "enemy_7",
   layer = 1,
   x = 64,
   y = 160,
+  pattern = "placeholder.enemy",
   width = 32,
   height = 32,
-  name = "enemy_7",
-  pattern = "placeholder.enemy",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "enemy_8",
   layer = 1,
   x = 224,
   y = 48,
+  pattern = "placeholder.enemy",
   width = 32,
   height = 32,
-  name = "enemy_8",
-  pattern = "placeholder.enemy",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "enemy_9",
   layer = 1,
   x = 224,
   y = 160,
+  pattern = "placeholder.enemy",
   width = 32,
   height = 32,
-  name = "enemy_9",
-  pattern = "placeholder.enemy",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "chest",
   layer = 1,
   x = 152,
   y = 112,
+  pattern = "placeholder.treasure_open",
   width = 16,
   height = 16,
-  name = "chest",
-  pattern = "placeholder.treasure_open",
   enabled_at_start = true,
 }
 
+tile{
+  layer = 2,
+  x = 0,
+  y = 0,
+  width = 320,
+  height = 8,
+  pattern = "ceiling",
+}
+
+tile{
+  layer = 2,
+  x = 0,
+  y = 232,
+  width = 320,
+  height = 8,
+  pattern = "ceiling",
+}
+
+tile{
+  layer = 2,
+  x = 0,
+  y = 8,
+  width = 8,
+  height = 224,
+  pattern = "ceiling",
+}
+
+tile{
+  layer = 2,
+  x = 312,
+  y = 8,
+  width = 8,
+  height = 224,
+  pattern = "ceiling",
+}
 

--- a/data/maps/components/treasure_open/treasure_open_000777_4.dat
+++ b/data/maps/components/treasure_open/treasure_open_000777_4.dat
@@ -11,6 +11,15 @@ properties{
 
 tile{
   layer = 1,
+  x = 24,
+  y = 24,
+  width = 272,
+  height = 192,
+  pattern = "placeholder.floor.high",
+}
+
+tile{
+  layer = 1,
   x = 104,
   y = 56,
   width = 112,
@@ -225,11 +234,190 @@ tile{
   pattern = "floor_torch.lit",
 }
 
+tile{
+  layer = 1,
+  x = 8,
+  y = 8,
+  width = 24,
+  height = 24,
+  pattern = "high_wall_inner_corner.nw",
+}
+
+tile{
+  layer = 1,
+  x = 288,
+  y = 8,
+  width = 24,
+  height = 24,
+  pattern = "high_wall_inner_corner.ne",
+}
+
+tile{
+  layer = 1,
+  x = 8,
+  y = 208,
+  width = 24,
+  height = 24,
+  pattern = "high_wall_inner_corner.sw",
+}
+
+tile{
+  layer = 1,
+  x = 288,
+  y = 208,
+  width = 24,
+  height = 24,
+  pattern = "high_wall_inner_corner.se",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 8,
+  width = 96,
+  height = 24,
+  pattern = "high_wall.n",
+}
+
+tile{
+  layer = 1,
+  x = 192,
+  y = 8,
+  width = 96,
+  height = 24,
+  pattern = "high_wall.n",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 208,
+  width = 96,
+  height = 24,
+  pattern = "high_wall.s",
+}
+
+tile{
+  layer = 1,
+  x = 192,
+  y = 208,
+  width = 96,
+  height = 24,
+  pattern = "high_wall.s",
+}
+
+tile{
+  layer = 1,
+  x = 8,
+  y = 144,
+  width = 24,
+  height = 64,
+  pattern = "high_wall.w",
+}
+
+tile{
+  layer = 1,
+  x = 8,
+  y = 32,
+  width = 24,
+  height = 64,
+  pattern = "high_wall.w",
+}
+
+tile{
+  layer = 1,
+  x = 288,
+  y = 32,
+  width = 24,
+  height = 64,
+  pattern = "high_wall.e",
+}
+
+tile{
+  layer = 1,
+  x = 288,
+  y = 144,
+  width = 24,
+  height = 64,
+  pattern = "high_wall.e",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 200,
+  width = 256,
+  height = 8,
+  pattern = "wall_border.high.s",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 32,
+  width = 256,
+  height = 8,
+  pattern = "wall_border.high.n",
+}
+
+tile{
+  layer = 1,
+  x = 280,
+  y = 32,
+  width = 8,
+  height = 176,
+  pattern = "wall_border.high.e",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 32,
+  width = 8,
+  height = 176,
+  pattern = "wall_border.high.w",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 32,
+  width = 8,
+  height = 8,
+  pattern = "wall_border_inner_corner.high.nw",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 200,
+  width = 8,
+  height = 8,
+  pattern = "wall_border_inner_corner.high.sw",
+}
+
+tile{
+  layer = 1,
+  x = 280,
+  y = 200,
+  width = 8,
+  height = 8,
+  pattern = "wall_border_inner_corner.high.se",
+}
+
+tile{
+  layer = 1,
+  x = 280,
+  y = 32,
+  width = 8,
+  height = 8,
+  pattern = "wall_border_inner_corner.high.ne",
+}
+
 block{
   layer = 1,
   x = 128,
   y = 85,
-  direction = -1,
   sprite = "entities/statue",
   pushable = false,
   pullable = false,
@@ -240,7 +428,6 @@ block{
   layer = 1,
   x = 192,
   y = 85,
-  direction = -1,
   sprite = "entities/statue",
   pushable = false,
   pullable = false,
@@ -248,47 +435,82 @@ block{
 }
 
 dynamic_tile{
+  name = "chest",
   layer = 1,
   x = 152,
   y = 72,
+  pattern = "placeholder.treasure_open",
   width = 16,
   height = 16,
-  name = "chest",
-  pattern = "placeholder.treasure_open",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "enemy_1",
   layer = 1,
   x = 112,
   y = 112,
+  pattern = "placeholder.enemy",
   width = 32,
   height = 32,
-  name = "enemy_1",
-  pattern = "placeholder.enemy",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "enemy_2",
   layer = 1,
   x = 176,
   y = 112,
+  pattern = "placeholder.enemy",
   width = 32,
   height = 32,
-  name = "enemy_2",
-  pattern = "placeholder.enemy",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "enemy_3",
   layer = 1,
   x = 144,
   y = 160,
+  pattern = "placeholder.enemy",
   width = 32,
   height = 32,
-  name = "enemy_3",
-  pattern = "placeholder.enemy",
   enabled_at_start = true,
 }
 
+tile{
+  layer = 2,
+  x = 0,
+  y = 0,
+  width = 320,
+  height = 8,
+  pattern = "ceiling",
+}
+
+tile{
+  layer = 2,
+  x = 0,
+  y = 232,
+  width = 320,
+  height = 8,
+  pattern = "ceiling",
+}
+
+tile{
+  layer = 2,
+  x = 312,
+  y = 8,
+  width = 8,
+  height = 224,
+  pattern = "ceiling",
+}
+
+tile{
+  layer = 2,
+  x = 0,
+  y = 8,
+  width = 8,
+  height = 224,
+  pattern = "ceiling",
+}
 

--- a/data/maps/components/treasure_open/treasure_open_000777_5.dat
+++ b/data/maps/components/treasure_open/treasure_open_000777_5.dat
@@ -11,6 +11,33 @@ properties{
 
 tile{
   layer = 1,
+  x = 24,
+  y = 24,
+  width = 272,
+  height = 192,
+  pattern = "placeholder.floor.high",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 8,
+  width = 96,
+  height = 24,
+  pattern = "high_wall.n",
+}
+
+tile{
+  layer = 1,
+  x = 192,
+  y = 8,
+  width = 96,
+  height = 24,
+  pattern = "high_wall.n",
+}
+
+tile{
+  layer = 1,
   x = 72,
   y = 56,
   width = 48,
@@ -88,6 +115,168 @@ tile{
   width = 16,
   height = 16,
   pattern = "small_statue.1",
+}
+
+tile{
+  layer = 1,
+  x = 8,
+  y = 8,
+  width = 24,
+  height = 24,
+  pattern = "high_wall_inner_corner.nw",
+}
+
+tile{
+  layer = 1,
+  x = 288,
+  y = 8,
+  width = 24,
+  height = 24,
+  pattern = "high_wall_inner_corner.ne",
+}
+
+tile{
+  layer = 1,
+  x = 288,
+  y = 208,
+  width = 24,
+  height = 24,
+  pattern = "high_wall_inner_corner.se",
+}
+
+tile{
+  layer = 1,
+  x = 8,
+  y = 208,
+  width = 24,
+  height = 24,
+  pattern = "high_wall_inner_corner.sw",
+}
+
+tile{
+  layer = 1,
+  x = 8,
+  y = 32,
+  width = 24,
+  height = 64,
+  pattern = "high_wall.w",
+}
+
+tile{
+  layer = 1,
+  x = 8,
+  y = 144,
+  width = 24,
+  height = 64,
+  pattern = "high_wall.w",
+}
+
+tile{
+  layer = 1,
+  x = 288,
+  y = 32,
+  width = 24,
+  height = 64,
+  pattern = "high_wall.e",
+}
+
+tile{
+  layer = 1,
+  x = 288,
+  y = 144,
+  width = 24,
+  height = 64,
+  pattern = "high_wall.e",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 208,
+  width = 96,
+  height = 24,
+  pattern = "high_wall.s",
+}
+
+tile{
+  layer = 1,
+  x = 192,
+  y = 208,
+  width = 96,
+  height = 24,
+  pattern = "high_wall.s",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 32,
+  width = 256,
+  height = 8,
+  pattern = "wall_border.high.n",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 200,
+  width = 256,
+  height = 8,
+  pattern = "wall_border.high.s",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 32,
+  width = 8,
+  height = 176,
+  pattern = "wall_border.high.w",
+}
+
+tile{
+  layer = 1,
+  x = 280,
+  y = 32,
+  width = 8,
+  height = 176,
+  pattern = "wall_border.high.e",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 32,
+  width = 8,
+  height = 8,
+  pattern = "wall_border_inner_corner.high.nw",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 200,
+  width = 8,
+  height = 8,
+  pattern = "wall_border_inner_corner.high.sw",
+}
+
+tile{
+  layer = 1,
+  x = 280,
+  y = 200,
+  width = 8,
+  height = 8,
+  pattern = "wall_border_inner_corner.high.se",
+}
+
+tile{
+  layer = 1,
+  x = 280,
+  y = 32,
+  width = 8,
+  height = 8,
+  pattern = "wall_border_inner_corner.high.ne",
 }
 
 enemy{
@@ -183,4 +372,39 @@ dynamic_tile{
   enabled_at_start = true,
 }
 
+tile{
+  layer = 2,
+  x = 0,
+  y = 0,
+  width = 320,
+  height = 8,
+  pattern = "ceiling",
+}
+
+tile{
+  layer = 2,
+  x = 0,
+  y = 232,
+  width = 320,
+  height = 8,
+  pattern = "ceiling",
+}
+
+tile{
+  layer = 2,
+  x = 312,
+  y = 8,
+  width = 8,
+  height = 224,
+  pattern = "ceiling",
+}
+
+tile{
+  layer = 2,
+  x = 0,
+  y = 8,
+  width = 8,
+  height = 224,
+  pattern = "ceiling",
+}
 

--- a/data/maps/components/treasure_open/treasure_open_200700_1.dat
+++ b/data/maps/components/treasure_open/treasure_open_200700_1.dat
@@ -11,6 +11,42 @@ properties{
 
 tile{
   layer = 1,
+  x = 24,
+  y = 24,
+  width = 272,
+  height = 80,
+  pattern = "placeholder.floor.high",
+}
+
+tile{
+  layer = 1,
+  x = 280,
+  y = 80,
+  width = 8,
+  height = 16,
+  pattern = "wall_border.high.e",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 80,
+  width = 8,
+  height = 16,
+  pattern = "wall_border.high.w",
+}
+
+tile{
+  layer = 1,
+  x = 80,
+  y = 32,
+  width = 160,
+  height = 8,
+  pattern = "wall_border.high.n",
+}
+
+tile{
+  layer = 1,
   x = 136,
   y = 56,
   width = 48,
@@ -225,6 +261,33 @@ tile{
   pattern = "wall_border_outer_corner.high.ne",
 }
 
+tile{
+  layer = 1,
+  x = 80,
+  y = 8,
+  width = 160,
+  height = 24,
+  pattern = "high_wall.n",
+}
+
+tile{
+  layer = 1,
+  x = 8,
+  y = 80,
+  width = 24,
+  height = 16,
+  pattern = "high_wall.w",
+}
+
+tile{
+  layer = 1,
+  x = 288,
+  y = 80,
+  width = 24,
+  height = 16,
+  pattern = "high_wall.e",
+}
+
 dynamic_tile{
   name = "enemy_3",
   layer = 1,
@@ -276,4 +339,30 @@ tile{
   pattern = "ceiling",
 }
 
+tile{
+  layer = 2,
+  x = 0,
+  y = 8,
+  width = 8,
+  height = 96,
+  pattern = "ceiling",
+}
+
+tile{
+  layer = 2,
+  x = 312,
+  y = 8,
+  width = 8,
+  height = 96,
+  pattern = "ceiling",
+}
+
+tile{
+  layer = 2,
+  x = 0,
+  y = 0,
+  width = 320,
+  height = 8,
+  pattern = "ceiling",
+}
 

--- a/data/maps/components/treasure_open/treasure_open_200770_1.dat
+++ b/data/maps/components/treasure_open/treasure_open_200770_1.dat
@@ -11,6 +11,33 @@ properties{
 
 tile{
   layer = 1,
+  x = 24,
+  y = 24,
+  width = 272,
+  height = 112,
+  pattern = "placeholder.floor.high",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 32,
+  width = 8,
+  height = 96,
+  pattern = "wall_border.high.w",
+}
+
+tile{
+  layer = 1,
+  x = 280,
+  y = 32,
+  width = 8,
+  height = 96,
+  pattern = "wall_border.high.e",
+}
+
+tile{
+  layer = 1,
   x = 120,
   y = 56,
   width = 16,
@@ -198,37 +225,153 @@ tile{
   pattern = "big_stage_carpet",
 }
 
+tile{
+  layer = 1,
+  x = 8,
+  y = 8,
+  width = 24,
+  height = 24,
+  pattern = "high_wall_inner_corner.nw",
+}
+
+tile{
+  layer = 1,
+  x = 288,
+  y = 8,
+  width = 24,
+  height = 24,
+  pattern = "high_wall_inner_corner.ne",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 8,
+  width = 256,
+  height = 24,
+  pattern = "high_wall.n",
+}
+
+tile{
+  layer = 1,
+  x = 8,
+  y = 32,
+  width = 24,
+  height = 64,
+  pattern = "high_wall.w",
+}
+
+tile{
+  layer = 1,
+  x = 288,
+  y = 32,
+  width = 24,
+  height = 64,
+  pattern = "high_wall.e",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 32,
+  width = 8,
+  height = 8,
+  pattern = "wall_border_inner_corner.high.nw",
+}
+
+tile{
+  layer = 1,
+  x = 280,
+  y = 32,
+  width = 8,
+  height = 8,
+  pattern = "wall_border_inner_corner.high.ne",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 32,
+  width = 256,
+  height = 8,
+  pattern = "wall_border.high.n",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 32,
+  width = 8,
+  height = 8,
+  pattern = "wall_border_inner_corner.high.nw",
+}
+
+tile{
+  layer = 1,
+  x = 280,
+  y = 32,
+  width = 8,
+  height = 8,
+  pattern = "wall_border_inner_corner.high.ne",
+}
+
 dynamic_tile{
+  name = "enemy_4",
   layer = 1,
   x = 72,
   y = 64,
+  pattern = "placeholder.enemy",
   width = 32,
   height = 32,
-  name = "enemy_4",
-  pattern = "placeholder.enemy",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "enemy_5",
   layer = 1,
   x = 216,
   y = 64,
+  pattern = "placeholder.enemy",
   width = 32,
   height = 32,
-  name = "enemy_5",
-  pattern = "placeholder.enemy",
   enabled_at_start = true,
 }
 
 dynamic_tile{
+  name = "chest",
   layer = 1,
   x = 152,
   y = 80,
+  pattern = "placeholder.treasure_open",
   width = 16,
   height = 16,
-  name = "chest",
-  pattern = "placeholder.treasure_open",
   enabled_at_start = true,
 }
 
+tile{
+  layer = 2,
+  x = 0,
+  y = 8,
+  width = 8,
+  height = 128,
+  pattern = "ceiling",
+}
+
+tile{
+  layer = 2,
+  x = 0,
+  y = 0,
+  width = 320,
+  height = 8,
+  pattern = "ceiling",
+}
+
+tile{
+  layer = 2,
+  x = 312,
+  y = 8,
+  width = 8,
+  height = 128,
+  pattern = "ceiling",
+}
 

--- a/data/maps/components/treasure_open/treasure_open_202777_1.dat
+++ b/data/maps/components/treasure_open/treasure_open_202777_1.dat
@@ -11,6 +11,114 @@ properties{
 
 tile{
   layer = 1,
+  x = 24,
+  y = 24,
+  width = 272,
+  height = 192,
+  pattern = "placeholder.floor.high",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 32,
+  width = 256,
+  height = 8,
+  pattern = "wall_border.high.n",
+}
+
+tile{
+  layer = 1,
+  x = 8,
+  y = 208,
+  width = 24,
+  height = 24,
+  pattern = "high_wall_inner_corner.sw",
+}
+
+tile{
+  layer = 1,
+  x = 288,
+  y = 208,
+  width = 24,
+  height = 24,
+  pattern = "high_wall_inner_corner.se",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 208,
+  width = 256,
+  height = 24,
+  pattern = "high_wall.s",
+}
+
+tile{
+  layer = 1,
+  x = 8,
+  y = 144,
+  width = 24,
+  height = 64,
+  pattern = "high_wall.w",
+}
+
+tile{
+  layer = 1,
+  x = 288,
+  y = 144,
+  width = 24,
+  height = 64,
+  pattern = "high_wall.e",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 200,
+  width = 256,
+  height = 8,
+  pattern = "wall_border.high.s",
+}
+
+tile{
+  layer = 1,
+  x = 280,
+  y = 32,
+  width = 8,
+  height = 176,
+  pattern = "wall_border.high.e",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 32,
+  width = 8,
+  height = 176,
+  pattern = "wall_border.high.w",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 200,
+  width = 8,
+  height = 8,
+  pattern = "wall_border_inner_corner.high.sw",
+}
+
+tile{
+  layer = 1,
+  x = 280,
+  y = 200,
+  width = 8,
+  height = 8,
+  pattern = "wall_border_inner_corner.high.se",
+}
+
+tile{
+  layer = 1,
   x = 144,
   y = 104,
   width = 32,
@@ -234,6 +342,69 @@ tile{
   pattern = "carpet_border",
 }
 
+tile{
+  layer = 1,
+  x = 32,
+  y = 32,
+  width = 8,
+  height = 8,
+  pattern = "wall_border_inner_corner.high.nw",
+}
+
+tile{
+  layer = 1,
+  x = 280,
+  y = 32,
+  width = 8,
+  height = 8,
+  pattern = "wall_border_inner_corner.high.ne",
+}
+
+tile{
+  layer = 1,
+  x = 8,
+  y = 8,
+  width = 24,
+  height = 24,
+  pattern = "high_wall_inner_corner.nw",
+}
+
+tile{
+  layer = 1,
+  x = 288,
+  y = 8,
+  width = 24,
+  height = 24,
+  pattern = "high_wall_inner_corner.ne",
+}
+
+tile{
+  layer = 1,
+  x = 288,
+  y = 32,
+  width = 24,
+  height = 64,
+  pattern = "high_wall.e",
+}
+
+tile{
+  layer = 1,
+  x = 8,
+  y = 32,
+  width = 24,
+  height = 64,
+  pattern = "high_wall.w",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 8,
+  width = 256,
+  height = 24,
+  pattern = "high_wall.n",
+}
+
 enemy{
   layer = 1,
   x = 112,
@@ -277,4 +448,39 @@ enemy{
   breed = "pike_auto",
 }
 
+tile{
+  layer = 2,
+  x = 0,
+  y = 232,
+  width = 320,
+  height = 8,
+  pattern = "ceiling",
+}
+
+tile{
+  layer = 2,
+  x = 312,
+  y = 8,
+  width = 8,
+  height = 224,
+  pattern = "ceiling",
+}
+
+tile{
+  layer = 2,
+  x = 0,
+  y = 8,
+  width = 8,
+  height = 224,
+  pattern = "ceiling",
+}
+
+tile{
+  layer = 2,
+  x = 0,
+  y = 0,
+  width = 320,
+  height = 8,
+  pattern = "ceiling",
+}
 

--- a/data/maps/dev/templates.dat
+++ b/data/maps/dev/templates.dat
@@ -1,0 +1,1108 @@
+properties{
+  x = 0,
+  y = 0,
+  width = 3200,
+  height = 2400,
+  min_layer = 0,
+  max_layer = 2,
+  tileset = "dungeon.tower_of_hera",
+}
+
+tile{
+  layer = 1,
+  x = 24,
+  y = 392,
+  width = 112,
+  height = 80,
+  pattern = "placeholder.floor.high",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 400,
+  width = 8,
+  height = 64,
+  pattern = "wall_border.high.w",
+}
+
+tile{
+  layer = 1,
+  x = 504,
+  y = 24,
+  width = 112,
+  height = 80,
+  pattern = "placeholder.floor.high",
+}
+
+tile{
+  layer = 1,
+  x = 600,
+  y = 32,
+  width = 8,
+  height = 64,
+  pattern = "wall_border.high.e",
+}
+
+tile{
+  layer = 1,
+  x = 504,
+  y = 152,
+  width = 112,
+  height = 192,
+  pattern = "placeholder.floor.high",
+}
+
+tile{
+  layer = 1,
+  x = 512,
+  y = 160,
+  width = 96,
+  height = 8,
+  pattern = "wall_border.high.n",
+}
+
+tile{
+  layer = 1,
+  x = 184,
+  y = 392,
+  width = 272,
+  height = 80,
+  pattern = "placeholder.floor.high",
+}
+
+tile{
+  layer = 1,
+  x = 192,
+  y = 400,
+  width = 8,
+  height = 64,
+  pattern = "wall_border.high.w",
+}
+
+tile{
+  layer = 1,
+  x = 440,
+  y = 400,
+  width = 8,
+  height = 64,
+  pattern = "wall_border.high.e",
+}
+
+tile{
+  layer = 1,
+  x = 24,
+  y = 152,
+  width = 112,
+  height = 192,
+  pattern = "placeholder.floor.high",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 160,
+  width = 8,
+  height = 176,
+  pattern = "wall_border.high.w",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 328,
+  width = 96,
+  height = 8,
+  pattern = "wall_border.high.s",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 160,
+  width = 96,
+  height = 8,
+  pattern = "wall_border.high.n",
+}
+
+tile{
+  layer = 1,
+  x = 24,
+  y = 24,
+  width = 112,
+  height = 80,
+  pattern = "placeholder.floor.high",
+}
+
+tile{
+  layer = 1,
+  x = 8,
+  y = 8,
+  width = 24,
+  height = 24,
+  pattern = "high_wall_inner_corner.nw",
+}
+
+tile{
+  layer = 1,
+  x = 8,
+  y = 32,
+  width = 24,
+  height = 64,
+  pattern = "high_wall.w",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 8,
+  width = 96,
+  height = 24,
+  pattern = "high_wall.n",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 32,
+  width = 96,
+  height = 8,
+  pattern = "wall_border.high.n",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 32,
+  width = 8,
+  height = 64,
+  pattern = "wall_border.high.w",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 32,
+  width = 8,
+  height = 8,
+  pattern = "wall_border_inner_corner.high.nw",
+}
+
+tile{
+  layer = 1,
+  x = 184,
+  y = 24,
+  width = 272,
+  height = 80,
+  pattern = "placeholder.floor.high",
+}
+
+tile{
+  layer = 1,
+  x = 168,
+  y = 8,
+  width = 24,
+  height = 24,
+  pattern = "high_wall_inner_corner.nw",
+}
+
+tile{
+  layer = 1,
+  x = 448,
+  y = 8,
+  width = 24,
+  height = 24,
+  pattern = "high_wall_inner_corner.ne",
+}
+
+tile{
+  layer = 1,
+  x = 192,
+  y = 8,
+  width = 96,
+  height = 24,
+  pattern = "high_wall.n",
+}
+
+tile{
+  layer = 1,
+  x = 352,
+  y = 8,
+  width = 96,
+  height = 24,
+  pattern = "high_wall.n",
+}
+
+tile{
+  layer = 1,
+  x = 168,
+  y = 32,
+  width = 24,
+  height = 64,
+  pattern = "high_wall.w",
+}
+
+tile{
+  layer = 1,
+  x = 448,
+  y = 32,
+  width = 24,
+  height = 64,
+  pattern = "high_wall.e",
+}
+
+tile{
+  layer = 1,
+  x = 192,
+  y = 32,
+  width = 256,
+  height = 8,
+  pattern = "wall_border.high.n",
+}
+
+tile{
+  layer = 1,
+  x = 192,
+  y = 32,
+  width = 8,
+  height = 64,
+  pattern = "wall_border.high.w",
+}
+
+tile{
+  layer = 1,
+  x = 440,
+  y = 32,
+  width = 8,
+  height = 64,
+  pattern = "wall_border.high.e",
+}
+
+tile{
+  layer = 1,
+  x = 192,
+  y = 32,
+  width = 8,
+  height = 8,
+  pattern = "wall_border_inner_corner.high.nw",
+}
+
+tile{
+  layer = 1,
+  x = 440,
+  y = 32,
+  width = 8,
+  height = 8,
+  pattern = "wall_border_inner_corner.high.ne",
+}
+
+tile{
+  layer = 1,
+  x = 184,
+  y = 152,
+  width = 272,
+  height = 192,
+  pattern = "placeholder.floor.high",
+}
+
+tile{
+  layer = 1,
+  x = 168,
+  y = 136,
+  width = 24,
+  height = 24,
+  pattern = "high_wall_inner_corner.nw",
+}
+
+tile{
+  layer = 1,
+  x = 448,
+  y = 136,
+  width = 24,
+  height = 24,
+  pattern = "high_wall_inner_corner.ne",
+}
+
+tile{
+  layer = 1,
+  x = 168,
+  y = 336,
+  width = 24,
+  height = 24,
+  pattern = "high_wall_inner_corner.sw",
+}
+
+tile{
+  layer = 1,
+  x = 448,
+  y = 336,
+  width = 24,
+  height = 24,
+  pattern = "high_wall_inner_corner.se",
+}
+
+tile{
+  layer = 1,
+  x = 192,
+  y = 136,
+  width = 96,
+  height = 24,
+  pattern = "high_wall.n",
+}
+
+tile{
+  layer = 1,
+  x = 352,
+  y = 136,
+  width = 96,
+  height = 24,
+  pattern = "high_wall.n",
+}
+
+tile{
+  layer = 1,
+  x = 168,
+  y = 272,
+  width = 24,
+  height = 64,
+  pattern = "high_wall.w",
+}
+
+tile{
+  layer = 1,
+  x = 168,
+  y = 160,
+  width = 24,
+  height = 64,
+  pattern = "high_wall.w",
+}
+
+tile{
+  layer = 1,
+  x = 448,
+  y = 160,
+  width = 24,
+  height = 64,
+  pattern = "high_wall.e",
+}
+
+tile{
+  layer = 1,
+  x = 448,
+  y = 272,
+  width = 24,
+  height = 64,
+  pattern = "high_wall.e",
+}
+
+tile{
+  layer = 1,
+  x = 192,
+  y = 336,
+  width = 96,
+  height = 24,
+  pattern = "high_wall.s",
+}
+
+tile{
+  layer = 1,
+  x = 352,
+  y = 336,
+  width = 96,
+  height = 24,
+  pattern = "high_wall.s",
+}
+
+tile{
+  layer = 1,
+  x = 192,
+  y = 160,
+  width = 256,
+  height = 8,
+  pattern = "wall_border.high.n",
+}
+
+tile{
+  layer = 1,
+  x = 192,
+  y = 328,
+  width = 256,
+  height = 8,
+  pattern = "wall_border.high.s",
+}
+
+tile{
+  layer = 1,
+  x = 192,
+  y = 160,
+  width = 8,
+  height = 176,
+  pattern = "wall_border.high.w",
+}
+
+tile{
+  layer = 1,
+  x = 440,
+  y = 160,
+  width = 8,
+  height = 176,
+  pattern = "wall_border.high.e",
+}
+
+tile{
+  layer = 1,
+  x = 192,
+  y = 160,
+  width = 8,
+  height = 8,
+  pattern = "wall_border_inner_corner.high.nw",
+}
+
+tile{
+  layer = 1,
+  x = 192,
+  y = 328,
+  width = 8,
+  height = 8,
+  pattern = "wall_border_inner_corner.high.sw",
+}
+
+tile{
+  layer = 1,
+  x = 440,
+  y = 328,
+  width = 8,
+  height = 8,
+  pattern = "wall_border_inner_corner.high.se",
+}
+
+tile{
+  layer = 1,
+  x = 440,
+  y = 160,
+  width = 8,
+  height = 8,
+  pattern = "wall_border_inner_corner.high.ne",
+}
+
+tile{
+  layer = 1,
+  x = 504,
+  y = 392,
+  width = 112,
+  height = 80,
+  pattern = "placeholder.floor.high",
+}
+
+tile{
+  layer = 1,
+  x = 512,
+  y = 464,
+  width = 96,
+  height = 24,
+  pattern = "high_wall.s",
+}
+
+tile{
+  layer = 1,
+  x = 608,
+  y = 464,
+  width = 24,
+  height = 24,
+  pattern = "high_wall_inner_corner.se",
+}
+
+tile{
+  layer = 1,
+  x = 608,
+  y = 400,
+  width = 24,
+  height = 64,
+  pattern = "high_wall.e",
+}
+
+tile{
+  layer = 1,
+  x = 512,
+  y = 456,
+  width = 96,
+  height = 8,
+  pattern = "wall_border.high.s",
+}
+
+tile{
+  layer = 1,
+  x = 600,
+  y = 400,
+  width = 8,
+  height = 64,
+  pattern = "wall_border.high.e",
+}
+
+tile{
+  layer = 1,
+  x = 600,
+  y = 456,
+  width = 8,
+  height = 8,
+  pattern = "wall_border_inner_corner.high.se",
+}
+
+tile{
+  layer = 1,
+  x = 8,
+  y = 136,
+  width = 24,
+  height = 24,
+  pattern = "high_wall_inner_corner.nw",
+}
+
+tile{
+  layer = 1,
+  x = 8,
+  y = 336,
+  width = 24,
+  height = 24,
+  pattern = "high_wall_inner_corner.sw",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 136,
+  width = 96,
+  height = 24,
+  pattern = "high_wall.n",
+}
+
+tile{
+  layer = 1,
+  x = 8,
+  y = 272,
+  width = 24,
+  height = 64,
+  pattern = "high_wall.w",
+}
+
+tile{
+  layer = 1,
+  x = 8,
+  y = 160,
+  width = 24,
+  height = 64,
+  pattern = "high_wall.w",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 336,
+  width = 96,
+  height = 24,
+  pattern = "high_wall.s",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 160,
+  width = 8,
+  height = 8,
+  pattern = "wall_border_inner_corner.high.nw",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 328,
+  width = 8,
+  height = 8,
+  pattern = "wall_border_inner_corner.high.sw",
+}
+
+tile{
+  layer = 1,
+  x = 168,
+  y = 464,
+  width = 24,
+  height = 24,
+  pattern = "high_wall_inner_corner.sw",
+}
+
+tile{
+  layer = 1,
+  x = 448,
+  y = 464,
+  width = 24,
+  height = 24,
+  pattern = "high_wall_inner_corner.se",
+}
+
+tile{
+  layer = 1,
+  x = 168,
+  y = 400,
+  width = 24,
+  height = 64,
+  pattern = "high_wall.w",
+}
+
+tile{
+  layer = 1,
+  x = 448,
+  y = 400,
+  width = 24,
+  height = 64,
+  pattern = "high_wall.e",
+}
+
+tile{
+  layer = 1,
+  x = 192,
+  y = 464,
+  width = 96,
+  height = 24,
+  pattern = "high_wall.s",
+}
+
+tile{
+  layer = 1,
+  x = 352,
+  y = 464,
+  width = 96,
+  height = 24,
+  pattern = "high_wall.s",
+}
+
+tile{
+  layer = 1,
+  x = 192,
+  y = 456,
+  width = 256,
+  height = 8,
+  pattern = "wall_border.high.s",
+}
+
+tile{
+  layer = 1,
+  x = 192,
+  y = 456,
+  width = 8,
+  height = 8,
+  pattern = "wall_border_inner_corner.high.sw",
+}
+
+tile{
+  layer = 1,
+  x = 440,
+  y = 456,
+  width = 8,
+  height = 8,
+  pattern = "wall_border_inner_corner.high.se",
+}
+
+tile{
+  layer = 1,
+  x = 608,
+  y = 136,
+  width = 24,
+  height = 24,
+  pattern = "high_wall_inner_corner.ne",
+}
+
+tile{
+  layer = 1,
+  x = 608,
+  y = 336,
+  width = 24,
+  height = 24,
+  pattern = "high_wall_inner_corner.se",
+}
+
+tile{
+  layer = 1,
+  x = 512,
+  y = 136,
+  width = 96,
+  height = 24,
+  pattern = "high_wall.n",
+}
+
+tile{
+  layer = 1,
+  x = 608,
+  y = 160,
+  width = 24,
+  height = 64,
+  pattern = "high_wall.e",
+}
+
+tile{
+  layer = 1,
+  x = 608,
+  y = 272,
+  width = 24,
+  height = 64,
+  pattern = "high_wall.e",
+}
+
+tile{
+  layer = 1,
+  x = 512,
+  y = 336,
+  width = 96,
+  height = 24,
+  pattern = "high_wall.s",
+}
+
+tile{
+  layer = 1,
+  x = 600,
+  y = 160,
+  width = 8,
+  height = 176,
+  pattern = "wall_border.high.e",
+}
+
+tile{
+  layer = 1,
+  x = 600,
+  y = 328,
+  width = 8,
+  height = 8,
+  pattern = "wall_border_inner_corner.high.se",
+}
+
+tile{
+  layer = 1,
+  x = 600,
+  y = 160,
+  width = 8,
+  height = 8,
+  pattern = "wall_border_inner_corner.high.ne",
+}
+
+tile{
+  layer = 1,
+  x = 512,
+  y = 328,
+  width = 96,
+  height = 8,
+  pattern = "wall_border.high.s",
+}
+
+tile{
+  layer = 1,
+  x = 600,
+  y = 328,
+  width = 8,
+  height = 8,
+  pattern = "wall_border_inner_corner.high.se",
+}
+
+tile{
+  layer = 1,
+  x = 512,
+  y = 32,
+  width = 96,
+  height = 8,
+  pattern = "wall_border.high.n",
+}
+
+tile{
+  layer = 1,
+  x = 608,
+  y = 8,
+  width = 24,
+  height = 24,
+  pattern = "high_wall_inner_corner.ne",
+}
+
+tile{
+  layer = 1,
+  x = 512,
+  y = 8,
+  width = 96,
+  height = 24,
+  pattern = "high_wall.n",
+}
+
+tile{
+  layer = 1,
+  x = 600,
+  y = 32,
+  width = 8,
+  height = 8,
+  pattern = "wall_border_inner_corner.high.ne",
+}
+
+tile{
+  layer = 1,
+  x = 608,
+  y = 32,
+  width = 24,
+  height = 64,
+  pattern = "high_wall.e",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 456,
+  width = 96,
+  height = 8,
+  pattern = "wall_border.high.s",
+}
+
+tile{
+  layer = 1,
+  x = 8,
+  y = 464,
+  width = 24,
+  height = 24,
+  pattern = "high_wall_inner_corner.sw",
+}
+
+tile{
+  layer = 1,
+  x = 8,
+  y = 400,
+  width = 24,
+  height = 64,
+  pattern = "high_wall.w",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 464,
+  width = 96,
+  height = 24,
+  pattern = "high_wall.s",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 456,
+  width = 8,
+  height = 8,
+  pattern = "wall_border_inner_corner.high.sw",
+}
+
+tile{
+  layer = 2,
+  x = 0,
+  y = 0,
+  width = 136,
+  height = 8,
+  pattern = "ceiling",
+}
+
+tile{
+  layer = 2,
+  x = 0,
+  y = 8,
+  width = 8,
+  height = 96,
+  pattern = "ceiling",
+}
+
+tile{
+  layer = 2,
+  x = 160,
+  y = 0,
+  width = 320,
+  height = 8,
+  pattern = "ceiling",
+}
+
+tile{
+  layer = 2,
+  x = 160,
+  y = 8,
+  width = 8,
+  height = 96,
+  pattern = "ceiling",
+}
+
+tile{
+  layer = 2,
+  x = 472,
+  y = 8,
+  width = 8,
+  height = 96,
+  pattern = "ceiling",
+}
+
+tile{
+  layer = 2,
+  x = 160,
+  y = 128,
+  width = 320,
+  height = 8,
+  pattern = "ceiling",
+}
+
+tile{
+  layer = 2,
+  x = 160,
+  y = 360,
+  width = 320,
+  height = 8,
+  pattern = "ceiling",
+}
+
+tile{
+  layer = 2,
+  x = 472,
+  y = 136,
+  width = 8,
+  height = 224,
+  pattern = "ceiling",
+}
+
+tile{
+  layer = 2,
+  x = 160,
+  y = 136,
+  width = 8,
+  height = 224,
+  pattern = "ceiling",
+}
+
+tile{
+  layer = 2,
+  x = 504,
+  y = 488,
+  width = 136,
+  height = 8,
+  pattern = "ceiling",
+}
+
+tile{
+  layer = 2,
+  x = 632,
+  y = 392,
+  width = 8,
+  height = 96,
+  pattern = "ceiling",
+}
+
+tile{
+  layer = 2,
+  x = 0,
+  y = 136,
+  width = 8,
+  height = 224,
+  pattern = "ceiling",
+}
+
+tile{
+  layer = 2,
+  x = 0,
+  y = 128,
+  width = 136,
+  height = 8,
+  pattern = "ceiling",
+}
+
+tile{
+  layer = 2,
+  x = 0,
+  y = 360,
+  width = 136,
+  height = 8,
+  pattern = "ceiling",
+}
+
+tile{
+  layer = 2,
+  x = 160,
+  y = 488,
+  width = 320,
+  height = 8,
+  pattern = "ceiling",
+}
+
+tile{
+  layer = 2,
+  x = 160,
+  y = 392,
+  width = 8,
+  height = 96,
+  pattern = "ceiling",
+}
+
+tile{
+  layer = 2,
+  x = 472,
+  y = 392,
+  width = 8,
+  height = 96,
+  pattern = "ceiling",
+}
+
+tile{
+  layer = 2,
+  x = 632,
+  y = 136,
+  width = 8,
+  height = 224,
+  pattern = "ceiling",
+}
+
+tile{
+  layer = 2,
+  x = 504,
+  y = 360,
+  width = 136,
+  height = 8,
+  pattern = "ceiling",
+}
+
+tile{
+  layer = 2,
+  x = 504,
+  y = 128,
+  width = 136,
+  height = 8,
+  pattern = "ceiling",
+}
+
+tile{
+  layer = 2,
+  x = 504,
+  y = 0,
+  width = 136,
+  height = 8,
+  pattern = "ceiling",
+}
+
+tile{
+  layer = 2,
+  x = 632,
+  y = 8,
+  width = 8,
+  height = 96,
+  pattern = "ceiling",
+}
+
+tile{
+  layer = 2,
+  x = 0,
+  y = 488,
+  width = 136,
+  height = 8,
+  pattern = "ceiling",
+}
+
+tile{
+  layer = 2,
+  x = 0,
+  y = 392,
+  width = 8,
+  height = 96,
+  pattern = "ceiling",
+}
+

--- a/data/maps/dev/templates.lua
+++ b/data/maps/dev/templates.lua
@@ -1,0 +1,24 @@
+-- Lua script of map dev/templates.
+-- This script is executed every time the hero enters this map.
+
+-- Feel free to modify the code below.
+-- You can add more events and remove the ones you don't need.
+
+-- See the Solarus Lua API documentation:
+-- http://www.solarus-games.org/doc/latest
+
+local map = ...
+local game = map:get_game()
+
+-- Event called at initialization time, as soon as this map becomes is loaded.
+function map:on_started()
+
+  -- You can initialize the movement and sprites of various
+  -- map entities here.
+end
+
+-- Event called after the opening transition effect of the map,
+-- that is, when the player takes control of the hero.
+function map:on_opening_transition_finished()
+
+end

--- a/data/maps/dungeons/dungeon1.lua
+++ b/data/maps/dungeons/dungeon1.lua
@@ -50,9 +50,7 @@ for i = 1, tier - 1 do
     end
 end
 
-local floor1, floor2 = zentropy.components:get_floors(presentation_rng:refine('floors'))
-
-local mapping = mappings.choose(tier, presentation_rng:refine('mappings'))
+local mapping = mappings.choose(tier, presentation_rng:refine('mapping'))
 zentropy.Room.enemies = mapping.enemies
 zentropy.Room.destructibles = mapping.destructibles
 zentropy.Room.enemy_ratio = get_enemy_ratio(tier)
@@ -61,6 +59,7 @@ local nkeys = zentropy.settings.tier_keys or mapping.complexity.keys
 local nfairies = zentropy.settings.tier_fairies or mapping.complexity.fairies
 local nculdesacs = zentropy.settings.tier_culdesacs or mapping.complexity.culdesacs
 local max_heads = zentropy.settings.tier_max_heads or mapping.complexity.max_heads
+local style = mapping.style_builder:get_elect()
 
 local step_deps = Quest.outline_graph(puzzle_rng, nkeys, nfairies, nculdesacs, treasure_items)
 local steps = Quest.sequence(puzzle_rng:refine('steps'), step_deps)
@@ -75,10 +74,10 @@ end
 
 
 if not sol.audio.get_music() then 
-	sol.audio.play_music(mapping.get_music(tier))
+	sol.audio.play_music(style.music)
 end
 
-local solarus_layout = Layout.solarus_mixin(layout:new{rng=layout_rng, style=mapping}, map)
+local solarus_layout = Layout.solarus_mixin(layout:new{rng=layout_rng, style=mapping.style_builder}, map)
 solarus_layout:render(puzzle)
 --Layout.print_mixin(layout:new()):render(puzzle)
 

--- a/data/maps/rooms/room1.dat
+++ b/data/maps/rooms/room1.dat
@@ -3,235 +3,216 @@ properties{
   y = 0,
   width = 320,
   height = 240,
-  world = "https://github.com/christopho/zsdx.git",
   min_layer = 0,
   max_layer = 2,
+  world = "https://github.com/christopho/zsdx.git",
   tileset = "dungeon.tower_of_hera",
   music = "same",
 }
 
 tile{
-  layer = 1,
-  x = 32,
-  y = 8,
-  width = 256,
-  height = 24,
-  pattern = "high_wall.n",
-}
-
-tile{
-  layer = 1,
-  x = 32,
-  y = 208,
-  width = 256,
-  height = 24,
-  pattern = "high_wall.s",
-}
-
-tile{
-  layer = 1,
-  x = 8,
-  y = 32,
-  width = 24,
-  height = 176,
-  pattern = "high_wall.w",
-}
-
-tile{
-  layer = 1,
-  x = 288,
-  y = 32,
-  width = 24,
-  height = 176,
-  pattern = "high_wall.e",
-}
-
-tile{
-  layer = 1,
-  x = 8,
-  y = 8,
-  width = 24,
-  height = 24,
-  pattern = "high_wall_inner_corner.nw",
-}
-
-tile{
-  layer = 1,
-  x = 288,
-  y = 8,
-  width = 24,
-  height = 24,
-  pattern = "high_wall_inner_corner.ne",
-}
-
-tile{
-  layer = 1,
-  x = 288,
-  y = 208,
-  width = 24,
-  height = 24,
-  pattern = "high_wall_inner_corner.se",
-}
-
-tile{
-  layer = 1,
-  x = 8,
-  y = 208,
-  width = 24,
-  height = 24,
-  pattern = "high_wall_inner_corner.sw",
-}
-
-tile{
-  layer = 1,
-  x = 32,
-  y = 32,
-  width = 256,
-  height = 8,
-  pattern = "wall_border.high.n",
-}
-
-tile{
-  layer = 1,
-  x = 32,
-  y = 200,
-  width = 256,
-  height = 8,
-  pattern = "wall_border.high.s",
-}
-
-tile{
-  layer = 1,
-  x = 32,
-  y = 32,
-  width = 8,
-  height = 176,
-  pattern = "wall_border.high.w",
-}
-
-tile{
-  layer = 1,
-  x = 280,
-  y = 32,
-  width = 8,
-  height = 176,
-  pattern = "wall_border.high.e",
-}
-
-tile{
-  layer = 1,
-  x = 32,
-  y = 32,
-  width = 8,
-  height = 8,
-  pattern = "wall_border_inner_corner.high.nw",
-}
-
-tile{
-  layer = 1,
-  x = 32,
-  y = 200,
-  width = 8,
-  height = 8,
-  pattern = "wall_border_inner_corner.high.sw",
-}
-
-tile{
-  layer = 1,
-  x = 280,
-  y = 200,
-  width = 8,
-  height = 8,
-  pattern = "wall_border_inner_corner.high.se",
-}
-
-tile{
-  layer = 1,
-  x = 280,
-  y = 32,
-  width = 8,
-  height = 8,
-  pattern = "wall_border_inner_corner.high.ne",
-}
-
-dynamic_tile{
-  layer = 1,
-  x = 152,
-  y = 16,
-  width = 16,
-  height = 16,
-  name = "crack_north",
-  pattern = "cracked_wall.n",
-  enabled_at_start = false,
-}
-
-dynamic_tile{
-  layer = 1,
-  x = 288,
-  y = 112,
-  width = 16,
-  height = 16,
-  name = "crack_east",
-  pattern = "cracked_wall.e",
-  enabled_at_start = false,
-}
-
-dynamic_tile{
-  layer = 1,
-  x = 152,
-  y = 208,
-  width = 16,
-  height = 16,
-  name = "crack_south",
-  pattern = "cracked_wall.s",
-  enabled_at_start = false,
-}
-
-dynamic_tile{
-  layer = 1,
-  x = 16,
-  y = 112,
-  width = 16,
-  height = 16,
-  name = "crack_west",
-  pattern = "cracked_wall.w",
-  enabled_at_start = false,
-}
-
-tile{
-  layer = 2,
-  x = 0,
-  y = 8,
-  width = 8,
-  height = 224,
-  pattern = "ceiling",
-}
-
-tile{
-  layer = 2,
-  x = 312,
-  y = 8,
-  width = 8,
-  height = 224,
-  pattern = "ceiling",
-}
-
-tile{
-  layer = 2,
+  layer = 0,
   x = 0,
   y = 0,
   width = 320,
-  height = 8,
-  pattern = "ceiling",
+  height = 240,
+  pattern = "lava_hole",
 }
 
 tile{
-  layer = 2,
-  x = 0,
-  y = 232,
-  width = 320,
-  height = 8,
-  pattern = "ceiling",
+  layer = 1,
+  x = 32,
+  y = 32,
+  width = 256,
+  height = 176,
+  pattern = "floor_net",
 }
 
+tile{
+  layer = 1,
+  x = 32,
+  y = 32,
+  width = 256,
+  height = 8,
+  pattern = "wall_border.low.n",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 200,
+  width = 256,
+  height = 8,
+  pattern = "wall_border.low.s",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 32,
+  width = 8,
+  height = 176,
+  pattern = "wall_border.low.w",
+}
+
+tile{
+  layer = 1,
+  x = 280,
+  y = 32,
+  width = 8,
+  height = 176,
+  pattern = "wall_border.low.e",
+}
+
+tile{
+  layer = 1,
+  x = 8,
+  y = 24,
+  width = 24,
+  height = 192,
+  pattern = "low_wall.w",
+}
+
+tile{
+  layer = 1,
+  x = 288,
+  y = 24,
+  width = 24,
+  height = 192,
+  pattern = "low_wall.e",
+}
+
+tile{
+  layer = 1,
+  x = 8,
+  y = 8,
+  width = 24,
+  height = 24,
+  pattern = "low_wall_inner_corner.nw",
+}
+
+tile{
+  layer = 1,
+  x = 8,
+  y = 208,
+  width = 24,
+  height = 24,
+  pattern = "low_wall_inner_corner.sw",
+}
+
+tile{
+  layer = 1,
+  x = 288,
+  y = 208,
+  width = 24,
+  height = 24,
+  pattern = "low_wall_inner_corner.se",
+}
+
+tile{
+  layer = 1,
+  x = 288,
+  y = 8,
+  width = 24,
+  height = 24,
+  pattern = "low_wall_inner_corner.ne",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 200,
+  width = 8,
+  height = 8,
+  pattern = "wall_border_inner_corner.low.sw",
+}
+
+tile{
+  layer = 1,
+  x = 280,
+  y = 32,
+  width = 8,
+  height = 8,
+  pattern = "wall_border_inner_corner.low.ne",
+}
+
+tile{
+  layer = 1,
+  x = 280,
+  y = 200,
+  width = 8,
+  height = 8,
+  pattern = "wall_border_inner_corner.low.se",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 32,
+  width = 8,
+  height = 8,
+  pattern = "wall_border_inner_corner.low.nw",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 8,
+  width = 256,
+  height = 24,
+  pattern = "low_wall.n",
+}
+
+tile{
+  layer = 1,
+  x = 32,
+  y = 208,
+  width = 256,
+  height = 24,
+  pattern = "low_wall.s",
+}
+
+dynamic_tile{
+  name = "crack_north",
+  layer = 1,
+  x = 152,
+  y = 16,
+  pattern = "cracked_wall.n",
+  width = 16,
+  height = 16,
+  enabled_at_start = false,
+}
+
+dynamic_tile{
+  name = "crack_east",
+  layer = 1,
+  x = 288,
+  y = 112,
+  pattern = "cracked_wall.e",
+  width = 16,
+  height = 16,
+  enabled_at_start = false,
+}
+
+dynamic_tile{
+  name = "crack_south",
+  layer = 1,
+  x = 152,
+  y = 208,
+  pattern = "cracked_wall.s",
+  width = 16,
+  height = 16,
+  enabled_at_start = false,
+}
+
+dynamic_tile{
+  name = "crack_west",
+  layer = 1,
+  x = 16,
+  y = 112,
+  pattern = "cracked_wall.w",
+  width = 16,
+  height = 16,
+  enabled_at_start = false,
+}
 

--- a/data/project_db.dat
+++ b/data/project_db.dat
@@ -53,6 +53,7 @@ map{ id = "components/filler/filler_000001_holestones", description = "Filler 00
 map{ id = "components/filler/filler_000001_statuestones", description = "Filler 000001 statuestones" }
 map{ id = "components/filler/filler_000001_stones", description = "Filler 000001 stones" }
 map{ id = "components/filler/filler_000001_torchstones", description = "Filler 000001 torchstones" }
+map{ id = "components/filler/filler_000002_empty", description = "Filler 000002 empty" }
 map{ id = "components/filler/filler_000004_1", description = "Filler 000004 1" }
 map{ id = "components/filler/filler_000004_12", description = "Filler 000004 12" }
 map{ id = "components/filler/filler_000004_12b", description = "Filler 000004 12b" }
@@ -69,7 +70,9 @@ map{ id = "components/filler/filler_000004_stones", description = "Filler 000004
 map{ id = "components/filler/filler_000004_torchstone", description = "Filler 000004 torchstone" }
 map{ id = "components/filler/filler_000007_1", description = "Filler 000007 1" }
 map{ id = "components/filler/filler_000007_barrierstones", description = "Filler 000007 barrierstones" }
+map{ id = "components/filler/filler_000010_empty", description = "Filler 000010 empty" }
 map{ id = "components/filler/filler_000020_1", description = "Filler 000020 1 enemy" }
+map{ id = "components/filler/filler_000040_empty", description = "Filler 000040 empty" }
 map{ id = "components/filler/filler_000100_1", description = "Filler 000100 1" }
 map{ id = "components/filler/filler_000100_12", description = "Filler 000100 12" }
 map{ id = "components/filler/filler_000100_12b", description = "Filler 000100 12b" }
@@ -87,6 +90,7 @@ map{ id = "components/filler/filler_000100_torchstones", description = "Filler 0
 map{ id = "components/filler/filler_000111_1", description = "Filler 000111 1 spikes" }
 map{ id = "components/filler/filler_000111_barrierstones", description = "Filler 000111 barrierstones" }
 map{ id = "components/filler/filler_000111_carpetstones", description = "Filler 000111 carpetstones" }
+map{ id = "components/filler/filler_000200_empty", description = "Filler 000200 empty" }
 map{ id = "components/filler/filler_000400_1", description = "Filler 000400 1" }
 map{ id = "components/filler/filler_000400_12", description = "Filler 000400 12" }
 map{ id = "components/filler/filler_000400_12b", description = "Filler 000400 12b" }
@@ -322,6 +326,7 @@ map{ id = "dev/best_practice", description = "Best practice" }
 map{ id = "dev/obstacles", description = "Obstacles" }
 map{ id = "dev/puzzles", description = "Puzzles" }
 map{ id = "dev/room_template", description = "Room1 template" }
+map{ id = "dev/templates", description = "Templates" }
 map{ id = "dev/tileset_test", description = "Tileset test" }
 map{ id = "dungeons/dungeon1", description = "Dungeon1" }
 map{ id = "rooms/cutscene", description = "Cutscene" }

--- a/data/project_db.dat
+++ b/data/project_db.dat
@@ -117,16 +117,19 @@ map{ id = "components/filler/filler_000777_6", description = "Filler 000777 6 Ba
 map{ id = "components/filler/filler_000777_7", description = "Filler 000777 7" }
 map{ id = "components/filler/filler_000777_8", description = "Filler 000777 8" }
 map{ id = "components/filler/filler_000777_9", description = "Filler 000777 9" }
+map{ id = "components/filler/filler_002000_wall_south", description = "Filler 002000 wall south" }
 map{ id = "components/filler/filler_002007_1", description = "Filler 002007 1" }
 map{ id = "components/filler/filler_002007_2", description = "Filler 002007 2" }
 map{ id = "components/filler/filler_002007_3", description = "Filler 002007 3" }
 map{ id = "components/filler/filler_002007_4", description = "Filler 002007 4" }
+map{ id = "components/filler/filler_010000_wall_east", description = "Filler 010000 wall east" }
 map{ id = "components/filler/filler_010111_1", description = "Filler 010111 1" }
 map{ id = "components/filler/filler_010111_2", description = "Filler 010111 2" }
 map{ id = "components/filler/filler_010111_3", description = "Filler 010111 3" }
 map{ id = "components/filler/filler_010111_4", description = "Filler 010111 4" }
 map{ id = "components/filler/filler_012117_1", description = "Filler 012117 1 water corner" }
 map{ id = "components/filler/filler_012117_2", description = "Filler 012117 2" }
+map{ id = "components/filler/filler_040000_wall_west", description = "Filler 040000 wall west" }
 map{ id = "components/filler/filler_040444_1", description = "Filler 040444 1" }
 map{ id = "components/filler/filler_040444_2", description = "Filler 040444 2" }
 map{ id = "components/filler/filler_040444_3", description = "Filler 040444 3" }
@@ -136,6 +139,7 @@ map{ id = "components/filler/filler_042447_2", description = "Filler 042447 2" }
 map{ id = "components/filler/filler_050777_1", description = "Filler 050777 1" }
 map{ id = "components/filler/filler_050777_2", description = "Filler 050777 2 Rats room" }
 map{ id = "components/filler/filler_050777_6", description = "Filler 050777 6 Pikes and statues" }
+map{ id = "components/filler/filler_200000_wall_north", description = "Filler 200000 wall north" }
 map{ id = "components/filler/filler_200700_1", description = "Filler 200700 1" }
 map{ id = "components/filler/filler_200700_2", description = "Filler 200700 2" }
 map{ id = "components/filler/filler_200700_3", description = "Filler 200700 3" }

--- a/script/runsed
+++ b/script/runsed
@@ -1,0 +1,28 @@
+#!/bin/sh
+
+BASE="`dirname "$0"`/.."
+
+compile () {
+    sed -E -e '
+    s:\s*$::
+    s:^//:#:
+    s:^([a-z0-9._]+),\s([a-z0-9._]+)$:s/(pattern|tileset) = "\1"/\\1 = "\2"/:
+    s:^([a-z0-9._]+)$:/"\1"/d:
+    '
+}
+SCRIPT="
+:loop
+/}/b done
+N
+s/\n//
+b loop
+/^$/d
+:done
+`compile < "$BASE/diff_delete"`
+`compile < "$BASE/diff_replace"`
+s/,/,\n/g
+s/\{/{\n/g
+s/\}/}\n/g
+/^$/D
+"
+find "$BASE/data/maps" -name '*.dat' -exec echo {} \; -exec sed -i -E "$SCRIPT" {} \;


### PR DESCRIPTION
* Changed room1 to have an under-construction look and started adding floors to components.
* Added a dev/template map for the most common masks to speed up the adding of floors.
* Added a few new empty filler components.
* Updated all components for tiers 1-6 of seed 1479752244.
* All included components print out their name to stdout.
* Included script/runsed (it seems I forgot to add it earlier).

Adding components affects which components get selected in some cases. If you've kept old seed values for reproducing certain things, this change may break some of those.

The updated components will need to be tweaked again once half wall and wall-border tiles are in place, but I think this gives a pretty decent feel for how things will work out.

I've adopted the following work flow:

1. Start Tunics! using this command:
   ```sh
   solarus-run | grep component | sort -u | sed 's,(.*),data/maps/\1.dat,' | xargs grep -L placeholder.floor.high
   ```
2. Enter a level
3. Save and quit
4. Open, update and save all listed components in the quest editor
5. Start Tunics! again (e.g. using the same command) and verify that all components seem to render properly.

One rough edge is that room1 has grating floor on layer 1. This messes up hole components. The grating isn't needed if you apply the work flow above, but I'm not sure if it's a good fit for you, so I kept it.

Three are three new known issues in addition to the missing half tiles and the target statue:

1. Doors don't render properly, and neither does lack of doors.
2. Different floors can be selected in the same room.
3. On tier 5 of seed 1479752244, there is a treasure that cannot be collected (the map). It seems there's a missing secondary chest in one of the components (use the compass to figure out which one).